### PR TITLE
feat: settings reset() and resetToDefaults()

### DIFF
--- a/src/lib/settings/settings.service.test.ts
+++ b/src/lib/settings/settings.service.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { createScope } from './settings.service'
+
+const { mockGet, mockSet, mockSave } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+  mockSave: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  LazyStore: vi.fn(function () {
+    return { get: mockGet, set: mockSet, save: mockSave }
+  }),
+}))
+
+const { mockReadJson, mockWriteJson, mockEnsureDir } = vi.hoisted(() => ({
+  mockReadJson: vi.fn(),
+  mockWriteJson: vi.fn(),
+  mockEnsureDir: vi.fn(),
+}))
+
+vi.mock('@/lib/fs', () => ({
+  readJson: mockReadJson,
+  writeJson: mockWriteJson,
+  ensureDir: mockEnsureDir,
+}))
+
+const TestSchema = z.object({ theme: z.string(), value: z.number() })
+const testDef = {
+  key: 'test',
+  version: 1,
+  schema: TestSchema,
+  defaults: { theme: 'system', value: 0 },
+}
+
+const WORKSPACE = '/workspace/test'
+
+describe('createScope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSave.mockResolvedValue(undefined)
+    mockSet.mockResolvedValue(undefined)
+    mockEnsureDir.mockResolvedValue(undefined)
+    mockWriteJson.mockResolvedValue(undefined)
+  })
+
+  describe('resetToDefaults()', () => {
+    it('sets state to hardcoded defaults', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({})
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      expect(scope.getState().theme).toBe('dark')
+
+      await scope.getState().resetToDefaults()
+
+      expect(scope.getState().theme).toBe('system')
+      expect(scope.getState().value).toBe(0)
+    })
+
+    it('persists defaults to global store', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({})
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      mockSet.mockClear()
+      mockSave.mockClear()
+
+      await scope.getState().resetToDefaults()
+
+      expect(mockSet).toHaveBeenCalledWith('test', {
+        _meta: { version: 1 },
+        data: testDef.defaults,
+      })
+      expect(mockSave).toHaveBeenCalled()
+    })
+
+    it("clears the scope's workspace delta so re-init does not re-apply stale overrides", async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson
+        .mockResolvedValueOnce({ test: { theme: 'light' } }) // init: workspace delta
+        .mockResolvedValueOnce({ test: { theme: 'light' } }) // resetToDefaults: removeWorkspaceDelta read
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      await scope.getState().resetToDefaults()
+
+      expect(mockWriteJson).toHaveBeenLastCalledWith(
+        `${WORKSPACE}/.config/settings.json`,
+        {},
+      )
+    })
+  })
+
+  describe('reset()', () => {
+    it('reverts effective state to global settings', async () => {
+      const globalData = { theme: 'dark', value: 5 }
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: globalData })
+      mockReadJson
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 } }) // init: workspace delta
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 } }) // reset: read file
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      expect(scope.getState().theme).toBe('light')
+
+      await scope.getState().reset()
+
+      expect(scope.getState().theme).toBe('dark')
+      expect(scope.getState().value).toBe(5)
+    })
+
+    it("removes the scope's key from the workspace delta file", async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson
+        .mockResolvedValueOnce({ test: { theme: 'light' }, other: { x: 1 } }) // init
+        .mockResolvedValueOnce({ test: { theme: 'light' }, other: { x: 1 } }) // reset
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      await scope.getState().reset()
+
+      expect(mockWriteJson).toHaveBeenLastCalledWith(
+        `${WORKSPACE}/.config/settings.json`,
+        { other: { x: 1 } },
+      )
+    })
+
+    it('does not modify global settings', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({})
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      mockSet.mockClear()
+
+      await scope.getState().reset()
+
+      expect(mockSet).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/settings/settings.service.ts
+++ b/src/lib/settings/settings.service.ts
@@ -34,6 +34,7 @@ export function createScope<TSchema extends z.ZodObject>(
   type Data = z.infer<TSchema>
 
   let _workspacePath: string | null = null
+  let _globalData: Data | null = null
 
   const persistGlobal = async (data: Data) => {
     await store.set(def.key, { _meta: { version: def.version }, data })
@@ -51,6 +52,18 @@ export function createScope<TSchema extends z.ZodObject>(
     } catch {
       return {}
     }
+  }
+
+  const removeWorkspaceDelta = async (workspacePath: string) => {
+    const settingsPath = `${workspacePath}/${WORKSPACE_SETTINGS_FILE}`
+    let all: Record<string, unknown> = {}
+    try {
+      all = await readJson<Record<string, unknown>>(settingsPath)
+    } catch {
+      return
+    }
+    delete all[def.key]
+    await writeJson(settingsPath, all)
   }
 
   const saveWorkspaceDelta = async (
@@ -100,6 +113,8 @@ export function createScope<TSchema extends z.ZodObject>(
         if (!parsed.success) await persistGlobal(globalData)
       }
 
+      _globalData = globalData
+
       const workspaceDelta = await loadWorkspaceDelta(workspacePath)
       const effective = resolveSettings(globalData, workspaceDelta)
 
@@ -113,6 +128,15 @@ export function createScope<TSchema extends z.ZodObject>(
     },
 
     reset: async () => {
+      const workspacePath = _workspacePath
+      const globalData = _globalData ?? def.defaults
+      if (workspacePath) await removeWorkspaceDelta(workspacePath)
+      set({ ...globalData } as Partial<ScopeStore<Data>>)
+    },
+
+    resetToDefaults: async () => {
+      const workspacePath = _workspacePath
+      if (workspacePath) await removeWorkspaceDelta(workspacePath)
       set({ ...def.defaults } as Partial<ScopeStore<Data>>)
       await persistGlobal(def.defaults)
     },

--- a/src/lib/settings/settings.types.ts
+++ b/src/lib/settings/settings.types.ts
@@ -18,4 +18,5 @@ export type ScopeStore<T> = T & {
   init: (workspacePath: string) => Promise<void>
   update: (patch: Partial<T>) => Promise<void>
   reset: () => Promise<void>
+  resetToDefaults: () => Promise<void>
 }


### PR DESCRIPTION
## Summary

- Adds `reset()` to `ScopeStore` — removes workspace overrides for the scope and reverts effective state to global settings, leaving global settings unchanged
- Renames the old `reset()` to `resetToDefaults()` — wipes state to hardcoded schema defaults, persists globally, and clears the workspace delta (fixing a bug where re-`init()` would silently re-apply stale overrides)
- Adds `_globalData` closure variable in `createScope` so `reset()` can revert to global without a redundant store read

## Test plan

- [x] `resetToDefaults()` sets state to hardcoded defaults
- [x] `resetToDefaults()` persists defaults to global store
- [x] `resetToDefaults()` clears workspace delta so re-init cannot re-apply stale overrides
- [x] `reset()` reverts effective state to global settings
- [x] `reset()` removes the scope's key from the workspace delta file
- [x] `reset()` does not call `store.set` (global settings unchanged)

Closes #4