### PR TITLE
feat: settings UI override indicator

### DIFF
--- a/src/components/settings/OverrideIndicator.tsx
+++ b/src/components/settings/OverrideIndicator.tsx
@@ -1,0 +1,19 @@
+import { RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function OverrideIndicator({ onRevert }: { onRevert: () => void }) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-5 text-muted-foreground hover:text-foreground"
+        title="Revert to global setting"
+        onClick={onRevert}
+      >
+        <RotateCcw className="size-3" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -5,6 +5,7 @@ import { Switch } from '@/components/ui/switch'
 import type { Theme } from '@/lib/settings'
 import { useAppearanceSettings } from '@/lib/settings'
 import { cn } from '@/lib/utils'
+import { OverrideIndicator } from '../OverrideIndicator'
 
 const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
   { value: 'light', label: 'Light', icon: Sun },
@@ -16,6 +17,12 @@ export const AppearanceSection = () => {
   const theme = useAppearanceSettings((s) => s.theme)
   const autoSyncTheme = useAppearanceSettings((s) => s.autoSyncTheme)
   const update = useAppearanceSettings((s) => s.update)
+  const revertKey = useAppearanceSettings((s) => s.revertKey)
+  const workspaceDelta = useAppearanceSettings((s) => s.workspaceDelta)
+
+  const hasAutoSyncThemeOrThemeDelta =
+    workspaceDelta.autoSyncTheme !== undefined ||
+    workspaceDelta.theme !== undefined
 
   const handleAutoSyncThemeChange = (checked: boolean) => {
     update({ autoSyncTheme: theme === 'system' ? checked : false })
@@ -48,20 +55,30 @@ export const AppearanceSection = () => {
           </Button>
         ))}
       </div>
-      <Field
-        orientation="horizontal"
-        className={cn(theme !== 'system' && 'cursor-not-allowed opacity-50')}
-      >
-        <FieldContent>
-          <FieldLabel htmlFor="auto-sync-theme">Auto-sync theme</FieldLabel>
-        </FieldContent>
-        <Switch
-          id="auto-sync-theme"
-          disabled={theme !== 'system'}
-          checked={theme === 'system' ? autoSyncTheme : false}
-          onCheckedChange={handleAutoSyncThemeChange}
-        />
-      </Field>
+      <div className="flex items-center gap-2">
+        <Field
+          orientation="horizontal"
+          className={cn(theme !== 'system' && 'cursor-not-allowed opacity-50')}
+        >
+          <FieldContent>
+            <FieldLabel htmlFor="auto-sync-theme">Auto-sync theme</FieldLabel>
+          </FieldContent>
+          <Switch
+            id="auto-sync-theme"
+            disabled={theme !== 'system'}
+            checked={theme === 'system' ? autoSyncTheme : false}
+            onCheckedChange={handleAutoSyncThemeChange}
+          />
+        </Field>
+        {hasAutoSyncThemeOrThemeDelta && (
+          <OverrideIndicator
+            onRevert={() => {
+              revertKey('theme')
+              revertKey('autoSyncTheme')
+            }}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/lib/settings/settings.service.test.ts
+++ b/src/lib/settings/settings.service.test.ts
@@ -96,6 +96,92 @@ describe('createScope', () => {
     })
   })
 
+  describe('workspaceDelta', () => {
+    it('is empty before init', () => {
+      const scope = createScope(testDef)
+      expect(scope.getState().workspaceDelta).toEqual({})
+    })
+
+    it('reflects loaded workspace delta after init', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({ test: { theme: 'light' } })
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      expect(scope.getState().workspaceDelta).toEqual({ theme: 'light' })
+    })
+
+    it('is empty after reset()', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 } })
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 } })
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      await scope.getState().reset()
+
+      expect(scope.getState().workspaceDelta).toEqual({})
+    })
+
+    it('accumulates keys from update() into workspaceDelta', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({})
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      await scope.getState().update({ theme: 'light' })
+      expect(scope.getState().workspaceDelta).toEqual({ theme: 'light' })
+
+      await scope.getState().update({ value: 99 })
+      expect(scope.getState().workspaceDelta).toEqual({ theme: 'light', value: 99 })
+    })
+  })
+
+  describe('revertKey()', () => {
+    it('removes the key from workspaceDelta in state', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({ test: { theme: 'light', value: 99 } })
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      await scope.getState().revertKey('theme')
+
+      expect(scope.getState().workspaceDelta).toEqual({ value: 99 })
+    })
+
+    it('reverts state for that key to the global value', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson.mockResolvedValue({ test: { theme: 'light', value: 99 } })
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+
+      expect(scope.getState().theme).toBe('light')
+      await scope.getState().revertKey('theme')
+      expect(scope.getState().theme).toBe('dark')
+    })
+
+    it('persists the delta file without that key', async () => {
+      mockGet.mockResolvedValue({ _meta: { version: 1 }, data: { theme: 'dark', value: 5 } })
+      mockReadJson
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 } }) // init
+        .mockResolvedValueOnce({ test: { theme: 'light', value: 99 }, other: { x: 1 } }) // revertKey read
+
+      const scope = createScope(testDef)
+      await scope.getState().init(WORKSPACE)
+      await scope.getState().revertKey('theme')
+
+      expect(mockWriteJson).toHaveBeenLastCalledWith(
+        `${WORKSPACE}/.config/settings.json`,
+        { test: { value: 99 }, other: { x: 1 } },
+      )
+    })
+  })
+
   describe('reset()', () => {
     it('reverts effective state to global settings', async () => {
       const globalData = { theme: 'dark', value: 5 }

--- a/src/lib/settings/settings.service.ts
+++ b/src/lib/settings/settings.service.ts
@@ -86,6 +86,7 @@ export function createScope<TSchema extends z.ZodObject>(
   return create<ScopeStore<Data>>()((set) => ({
     ...def.defaults,
     _initialized: false,
+    workspaceDelta: {} as Partial<Data>,
 
     init: async (workspacePath: string) => {
       _workspacePath = workspacePath
@@ -118,20 +119,55 @@ export function createScope<TSchema extends z.ZodObject>(
       const workspaceDelta = await loadWorkspaceDelta(workspacePath)
       const effective = resolveSettings(globalData, workspaceDelta)
 
-      set({ ...effective, _initialized: true } as Partial<ScopeStore<Data>>)
+      set({ ...effective, workspaceDelta, _initialized: true } as Partial<ScopeStore<Data>>)
     },
 
     update: async (patch) => {
       const workspacePath = _workspacePath
-      set(patch as Partial<ScopeStore<Data>>)
+      set((prev) => ({
+        ...(patch as Partial<ScopeStore<Data>>),
+        workspaceDelta: { ...prev.workspaceDelta, ...patch },
+      }))
       if (workspacePath) await saveWorkspaceDelta(workspacePath, patch)
+    },
+
+    revertKey: async (key) => {
+      const workspacePath = _workspacePath
+      const globalData = _globalData ?? def.defaults
+
+      set((prev) => {
+        const nextDelta = { ...prev.workspaceDelta }
+        delete nextDelta[key]
+        return {
+          [key]: globalData[key],
+          workspaceDelta: nextDelta,
+        } as Partial<ScopeStore<Data>>
+      })
+
+      if (workspacePath) {
+        const settingsPath = `${workspacePath}/${WORKSPACE_SETTINGS_FILE}`
+        let all: Record<string, unknown> = {}
+        try {
+          all = await readJson<Record<string, unknown>>(settingsPath)
+        } catch {
+          return
+        }
+        const scopeDelta = { ...(all[def.key] as Record<string, unknown>) }
+        delete scopeDelta[key as string]
+        if (Object.keys(scopeDelta).length === 0) {
+          delete all[def.key]
+        } else {
+          all[def.key] = scopeDelta
+        }
+        await writeJson(settingsPath, all)
+      }
     },
 
     reset: async () => {
       const workspacePath = _workspacePath
       const globalData = _globalData ?? def.defaults
       if (workspacePath) await removeWorkspaceDelta(workspacePath)
-      set({ ...globalData } as Partial<ScopeStore<Data>>)
+      set({ ...globalData, workspaceDelta: {} } as Partial<ScopeStore<Data>>)
     },
 
     resetToDefaults: async () => {

--- a/src/lib/settings/settings.service.ts
+++ b/src/lib/settings/settings.service.ts
@@ -173,7 +173,7 @@ export function createScope<TSchema extends z.ZodObject>(
     resetToDefaults: async () => {
       const workspacePath = _workspacePath
       if (workspacePath) await removeWorkspaceDelta(workspacePath)
-      set({ ...def.defaults } as Partial<ScopeStore<Data>>)
+      set({ ...def.defaults, workspaceDelta: {} } as Partial<ScopeStore<Data>>)
       await persistGlobal(def.defaults)
     },
   }))

--- a/src/lib/settings/settings.types.ts
+++ b/src/lib/settings/settings.types.ts
@@ -15,8 +15,10 @@ export interface PersistedScope<T> {
 
 export type ScopeStore<T> = T & {
   _initialized: boolean
+  workspaceDelta: Partial<T>
   init: (workspacePath: string) => Promise<void>
   update: (patch: Partial<T>) => Promise<void>
+  revertKey: (key: keyof T) => Promise<void>
   reset: () => Promise<void>
   resetToDefaults: () => Promise<void>
 }


### PR DESCRIPTION
## Summary

- Adds `workspaceDelta` field to `ScopeStore<T>` tracking which setting keys have workspace overrides
- Adds `revertKey(key)` to remove a single key from the workspace delta, immediately reverting that setting to its global value
- `reset()` and `resetToDefaults()` now clear `workspaceDelta` in state
- `AppearanceSection` shows an amber dot + revert button per overridden setting; indicator disappears on revert
- Extracts `OverrideIndicator` to `src/components/settings/OverrideIndicator.tsx` for use across all setting sections

Closes #5

## Test plan

- [x] `workspaceDelta` is `{}` before `init`
- [x] `workspaceDelta` reflects loaded workspace delta after `init`
- [x] `update()` accumulates keys into `workspaceDelta`
- [x] `reset()` clears `workspaceDelta`
- [x] `revertKey(key)` removes the key from `workspaceDelta`, reverts state to global, persists the delta file without that key
- [x] In the UI: open Settings → Appearance, change Theme or Auto-sync to create a workspace override → amber dot + revert icon appear → click revert → indicator disappears and value reverts to global