### PR TITLE
feat: theme system foundation — settings field and discovery service

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,3 +39,18 @@ A sparse delta of preference overrides scoped to a single Workspace, stored at `
 
 ### Tab
 An open Note in the editor. Multiple Tabs can be open simultaneously in a browser-like tab bar. Tabs persist across app restarts.
+
+### Theme
+A user-installed CSS customization for the app, consisting of a folder containing a `theme.css` file. Theme CSS is injected after the app's base styles — it augments rather than replaces them. The app's base styles always remain in effect, so a Theme that only overrides one CSS variable only changes that variable; the rest of the UI is unaffected. A Theme that targets `.dark` selectors only affects dark mode; light mode is untouched. The light/dark/system toggle works independently of Themes.
+
+Themes are discovered and resolved across two scopes: **Global Themes** (available to all Workspaces) and **Workspace Themes** (scoped to a single Workspace). When a Global Theme and a Workspace Theme share the same ID, the Workspace Theme takes precedence.
+
+A Theme's ID is its folder name. Renaming the folder changes the Theme's ID and breaks any saved reference to it.
+
+#### Global Theme
+A Theme installed in the OS app data directory, available across all Workspaces.
+
+#### Workspace Theme
+A Theme installed inside a Workspace's `.config/themes/[ThemeID]/` directory, scoped to that Workspace. Overrides a Global Theme with the same ID.
+
+> **CSS variable contract:** Theme authors can override any CSS variable or class the app currently exposes. No stability guarantee is made yet — the authoritative list and any public API contract will be defined as part of the planned CSS classes rethink.

--- a/docs/adr/0004-themes-as-css-overlays.md
+++ b/docs/adr/0004-themes-as-css-overlays.md
@@ -1,0 +1,11 @@
+# Themes as CSS overlays, not complete skins
+
+Themes are user-installed CSS customizations that are injected **after** the app's base styles. The app's base styles always remain in effect. A Theme that overrides one CSS variable changes only that variable; a Theme that targets `.dark` selectors affects only dark mode. The light/dark/system toggle works independently of Themes.
+
+A Theme is a folder containing a `theme.css` file. The folder name is the Theme's ID. Themes are resolved across two scopes — Global (app data directory) and Workspace (`.config/themes/[ID]/`) — with the Workspace scope taking precedence on ID collision.
+
+The alternative was treating Themes as complete skins that fully replace the app's visual layer. We rejected it for two reasons: first, a complete skin that omits any part of the UI leaves that part broken or invisible with no fallback — a user who ships an incomplete theme ships a broken app. Second, the overlay model naturally supports partial customizations (e.g. only changing the accent color, or only targeting dark mode), which is the majority of what users actually want. The safety guarantee — that the base styles always apply — means a user can never accidentally destroy the UI by dropping in a CSS file.
+
+The light/dark/system toggle was kept as an independent dimension rather than absorbed into the theme system, because themes may legitimately target only one mode and the toggle must remain meaningful regardless of what theme is active.
+
+No stability guarantee is made yet for which CSS variables or classes theme authors can rely on. A public CSS variable contract will be defined as part of a planned CSS classes rethink.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,3 +6,5 @@ export const DEFAULT_FOLDER_NAME = 'new-folder'
 export const SETTINGS_FILE = 'settings.json'
 export const WORKSPACE_CONFIG_DIR = '.config'
 export const WORKSPACE_SETTINGS_FILE = `${WORKSPACE_CONFIG_DIR}/${SETTINGS_FILE}`
+export const THEMES_DIR = 'themes'
+export const WORKSPACE_THEMES_DIR = `${WORKSPACE_CONFIG_DIR}/${THEMES_DIR}`

--- a/src/lib/fs/exists.ts
+++ b/src/lib/fs/exists.ts
@@ -5,3 +5,9 @@ export const exists = async (path: string) => {
     baseDir: BaseDirectory.Document,
   })
 }
+
+export const existsAppData = async (path: string) => {
+  return tauriExists(path, {
+    baseDir: BaseDirectory.AppData,
+  })
+}

--- a/src/lib/fs/read.ts
+++ b/src/lib/fs/read.ts
@@ -11,6 +11,12 @@ export const read = async (path: string) => {
   })
 }
 
+export const readDirAppData = async (path: string) => {
+  return readDirectory(path, {
+    baseDir: BaseDirectory.AppData,
+  })
+}
+
 export const readJson = async <T = unknown>(path: string) => {
   return read(path).then((data) => JSON.parse(data) as T)
 }

--- a/src/lib/settings/scopes/appearance.scope.ts
+++ b/src/lib/settings/scopes/appearance.scope.ts
@@ -11,6 +11,7 @@ export type Theme = (typeof Themes)[keyof typeof Themes]
 export const AppearanceSettings = z.object({
   theme: z.enum(Themes),
   autoSyncTheme: z.boolean(),
+  activeTheme: z.string().nullable().default(null),
 })
 export type AppearanceSettings = z.infer<typeof AppearanceSettings>
 
@@ -18,5 +19,5 @@ export const useAppearanceSettings = createScope({
   key: 'appearance',
   version: 1,
   schema: AppearanceSettings,
-  defaults: { theme: Themes.SYSTEM, autoSyncTheme: true },
+  defaults: { theme: Themes.SYSTEM, autoSyncTheme: true, activeTheme: null },
 })

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -1,0 +1,3 @@
+export * from './service'
+export * from './theme.types'
+export * from './utils'

--- a/src/lib/themes/service/index.ts
+++ b/src/lib/themes/service/index.ts
@@ -1,0 +1,1 @@
+export * from './load-themes'

--- a/src/lib/themes/service/load-themes.test.ts
+++ b/src/lib/themes/service/load-themes.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadThemes } from './load-themes'
+
+const { mockReadDir, mockReadDirAppData, mockExists, mockExistsAppData } =
+  vi.hoisted(() => ({
+    mockReadDir: vi.fn(),
+    mockReadDirAppData: vi.fn(),
+    mockExists: vi.fn(),
+    mockExistsAppData: vi.fn(),
+  }))
+
+vi.mock('@/lib/fs', () => ({
+  readDir: mockReadDir,
+  readDirAppData: mockReadDirAppData,
+  exists: mockExists,
+  existsAppData: mockExistsAppData,
+}))
+
+const dir = (name: string) => ({ name, isDirectory: true, isFile: false, isSymlink: false })
+const WORKSPACE = 'nemos-app/my-workspace'
+
+describe('loadThemes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when both theme directories do not exist', async () => {
+    mockReadDirAppData.mockRejectedValue(new Error('not found'))
+    mockReadDir.mockRejectedValue(new Error('not found'))
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result).toEqual([])
+  })
+
+  it('returns global themes when workspace directory does not exist', async () => {
+    mockReadDirAppData.mockResolvedValue([dir('nord')])
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadDir.mockRejectedValue(new Error('not found'))
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result).toEqual([{ id: 'nord', displayName: 'Nord' }])
+  })
+
+  it('returns workspace themes when global directory does not exist', async () => {
+    mockReadDirAppData.mockRejectedValue(new Error('not found'))
+    mockReadDir.mockResolvedValue([dir('my-theme')])
+    mockExists.mockResolvedValue(true)
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result).toEqual([{ id: 'my-theme', displayName: 'My Theme' }])
+  })
+
+  it('excludes folders missing theme.css', async () => {
+    mockReadDirAppData.mockResolvedValue([dir('no-css'), dir('has-css')])
+    mockExistsAppData
+      .mockResolvedValueOnce(false) // no-css/theme.css
+      .mockResolvedValueOnce(true)  // has-css/theme.css
+    mockReadDir.mockResolvedValue([])
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result).toEqual([{ id: 'has-css', displayName: 'Has Css' }])
+  })
+
+  it('workspace theme wins on ID collision', async () => {
+    mockReadDirAppData.mockResolvedValue([dir('shared-theme')])
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadDir.mockResolvedValue([dir('shared-theme')])
+    mockExists.mockResolvedValue(true)
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('shared-theme')
+  })
+
+  it('returns merged results sorted alphabetically by displayName', async () => {
+    mockReadDirAppData.mockResolvedValue([dir('zebra-theme')])
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadDir.mockResolvedValue([dir('apple-theme')])
+    mockExists.mockResolvedValue(true)
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result.map((t) => t.displayName)).toEqual(['Apple Theme', 'Zebra Theme'])
+  })
+
+  it('derives display name correctly from folder name', async () => {
+    mockReadDirAppData.mockResolvedValue([dir('my-dracula-theme')])
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadDir.mockResolvedValue([])
+
+    const result = await loadThemes(WORKSPACE)
+    expect(result[0].displayName).toBe('My Dracula Theme')
+  })
+})

--- a/src/lib/themes/service/load-themes.ts
+++ b/src/lib/themes/service/load-themes.ts
@@ -1,0 +1,55 @@
+import { THEMES_DIR, WORKSPACE_THEMES_DIR } from '@/config/constants'
+import { exists, existsAppData, readDir, readDirAppData } from '@/lib/fs'
+import type { ThemeDescriptor } from '../theme.types'
+import { mergeThemes, toDisplayName } from '../utils'
+
+const loadGlobalThemes = async (): Promise<ThemeDescriptor[]> => {
+  let entries: Awaited<ReturnType<typeof readDirAppData>>
+  try {
+    entries = await readDirAppData(THEMES_DIR)
+  } catch {
+    return []
+  }
+  const descriptors = await Promise.all(
+    entries
+      .filter((e) => e.isDirectory && e.name != null)
+      .map(async (e) => {
+        const hasCss = await existsAppData(`${THEMES_DIR}/${e.name}/theme.css`)
+        if (!hasCss) return null
+        return { id: e.name, displayName: toDisplayName(e.name) } satisfies ThemeDescriptor
+      }),
+  )
+  return descriptors.filter((d): d is ThemeDescriptor => d !== null)
+}
+
+const loadWorkspaceThemes = async (
+  workspaceFsPath: string,
+): Promise<ThemeDescriptor[]> => {
+  const themesPath = `${workspaceFsPath}/${WORKSPACE_THEMES_DIR}`
+  let entries: Awaited<ReturnType<typeof readDir>>
+  try {
+    entries = await readDir(themesPath)
+  } catch {
+    return []
+  }
+  const descriptors = await Promise.all(
+    entries
+      .filter((e) => e.isDirectory && e.name != null)
+      .map(async (e) => {
+        const hasCss = await exists(`${themesPath}/${e.name}/theme.css`)
+        if (!hasCss) return null
+        return { id: e.name, displayName: toDisplayName(e.name) } satisfies ThemeDescriptor
+      }),
+  )
+  return descriptors.filter((d): d is ThemeDescriptor => d !== null)
+}
+
+export const loadThemes = async (
+  workspaceFsPath: string,
+): Promise<ThemeDescriptor[]> => {
+  const [globalThemes, workspaceThemes] = await Promise.all([
+    loadGlobalThemes(),
+    loadWorkspaceThemes(workspaceFsPath),
+  ])
+  return mergeThemes(globalThemes, workspaceThemes)
+}

--- a/src/lib/themes/theme.types.ts
+++ b/src/lib/themes/theme.types.ts
@@ -1,0 +1,4 @@
+export interface ThemeDescriptor {
+  id: string
+  displayName: string
+}

--- a/src/lib/themes/utils.test.ts
+++ b/src/lib/themes/utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { AppearanceSettings } from '@/lib/settings'
+import type { ThemeDescriptor } from './theme.types'
+import { mergeThemes, toDisplayName } from './utils'
+
+describe('toDisplayName', () => {
+  it('replaces hyphens with spaces and title-cases each word', () => {
+    expect(toDisplayName('my-dracula-theme')).toBe('My Dracula Theme')
+  })
+
+  it('replaces underscores with spaces and title-cases each word', () => {
+    expect(toDisplayName('my_dark_theme')).toBe('My Dark Theme')
+  })
+
+  it('handles mixed hyphens and underscores', () => {
+    expect(toDisplayName('my_dracula-theme')).toBe('My Dracula Theme')
+  })
+
+  it('handles a single word', () => {
+    expect(toDisplayName('dracula')).toBe('Dracula')
+  })
+})
+
+describe('mergeThemes', () => {
+  const g = (id: string): ThemeDescriptor => ({ id, displayName: toDisplayName(id) })
+
+  it('returns global-only themes when no workspace themes exist', () => {
+    const result = mergeThemes([g('alpha'), g('beta')], [])
+    expect(result.map((t) => t.id)).toEqual(['alpha', 'beta'])
+  })
+
+  it('returns workspace-only themes when no global themes exist', () => {
+    const result = mergeThemes([], [g('gamma'), g('delta')])
+    expect(result.map((t) => t.id)).toEqual(['delta', 'gamma'])
+  })
+
+  it('workspace entry wins on ID collision', () => {
+    const globalTheme: ThemeDescriptor = { id: 'my-theme', displayName: 'Global Name' }
+    const workspaceTheme: ThemeDescriptor = { id: 'my-theme', displayName: 'Workspace Name' }
+    const result = mergeThemes([globalTheme], [workspaceTheme])
+    expect(result).toHaveLength(1)
+    expect(result[0].displayName).toBe('Workspace Name')
+  })
+
+  it('result is sorted alphabetically by displayName', () => {
+    const result = mergeThemes(
+      [g('zebra-theme'), g('apple-theme')],
+      [g('mango-theme')],
+    )
+    expect(result.map((t) => t.displayName)).toEqual([
+      'Apple Theme',
+      'Mango Theme',
+      'Zebra Theme',
+    ])
+  })
+
+  it('returns empty array when both lists are empty', () => {
+    expect(mergeThemes([], [])).toEqual([])
+  })
+})
+
+describe('AppearanceSettings schema — activeTheme', () => {
+  it('defaults activeTheme to null when field is missing', () => {
+    const result = AppearanceSettings.safeParse({ theme: 'system', autoSyncTheme: true })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.activeTheme).toBeNull()
+  })
+
+  it('accepts a string value for activeTheme', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+      activeTheme: 'my-theme',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.activeTheme).toBe('my-theme')
+  })
+
+  it('accepts null for activeTheme', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+      activeTheme: null,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.activeTheme).toBeNull()
+  })
+
+  it('rejects a number value for activeTheme', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+      activeTheme: 42,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a boolean value for activeTheme', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+      activeTheme: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/themes/utils.ts
+++ b/src/lib/themes/utils.ts
@@ -1,0 +1,18 @@
+import type { ThemeDescriptor } from './theme.types'
+
+export const toDisplayName = (folderName: string): string =>
+  folderName
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+
+export const mergeThemes = (
+  global: ThemeDescriptor[],
+  workspace: ThemeDescriptor[],
+): ThemeDescriptor[] => {
+  const merged = new Map<string, ThemeDescriptor>()
+  for (const theme of global) merged.set(theme.id, theme)
+  for (const theme of workspace) merged.set(theme.id, theme)
+  return [...merged.values()].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  )
+}


### PR DESCRIPTION
Closes #11

## Summary

- Adds `activeTheme: string | null` (default `null`) to `AppearanceSettings` Zod schema; uses `.default(null)` so existing stored data parses cleanly with no migration needed
- Adds `readDirAppData` and `existsAppData` FS wrappers using `BaseDirectory.AppData` for reading the global themes directory
- Implements `ThemeDescriptor` type, pure `mergeThemes` function (workspace wins on ID collision, sorted alphabetically), and `toDisplayName` helper (hyphens/underscores → spaces, title-cased)
- Implements `loadThemes(workspaceFsPath)` service that reads AppData `themes/` and workspace `.config/themes/`, silently skips folders missing `theme.css`, and delegates merging to the pure function

## Test plan

- [x] All 38 tests pass (`pnpm test`)
- [x] `mergeThemes` — global-only, workspace-only, ID collision (workspace wins), alphabetical sort
- [x] `toDisplayName` — hyphens, underscores, mixed (`my-dracula-theme` → `My Dracula Theme`)
- [x] `AppearanceSettings` schema — accepts string, accepts null, defaults missing field to null, rejects number/boolean
- [x] `loadThemes` — missing directories return `[]`, folders without `theme.css` excluded, global/workspace merge, display name derivation