### PR TITLE
feat: theme CSS injection in ThemeProvider

### DIFF
--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react'
 import { useAppearanceSettings } from '@/lib/settings'
+import { readThemeCss } from '@/lib/themes'
+
+const THEME_STYLE_ATTR = 'data-nemos-theme'
 
 function getSystemTheme(): 'light' | 'dark' {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -11,10 +14,28 @@ function applyTheme(resolved: 'light' | 'dark') {
   document.documentElement.classList.toggle('dark', resolved === 'dark')
 }
 
+function applyThemeCSS(css: string | null) {
+  const existing = document.querySelector(`[${THEME_STYLE_ATTR}]`)
+  if (!css) {
+    existing?.remove()
+    return
+  }
+  if (existing) {
+    existing.textContent = css
+  } else {
+    const style = document.createElement('style')
+    style.setAttribute(THEME_STYLE_ATTR, '')
+    style.textContent = css
+    document.head.appendChild(style)
+  }
+}
+
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const theme = useAppearanceSettings((s) => s.theme)
   const autoSyncTheme = useAppearanceSettings((s) => s.autoSyncTheme)
   const setTheme = useAppearanceSettings((s) => s.update)
+  const activeTheme = useAppearanceSettings((s) => s.activeTheme)
+  const workspacePath = useAppearanceSettings((s) => s.workspacePath)
 
   useEffect(() => {
     if (theme !== 'system') {
@@ -36,5 +57,20 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [theme, autoSyncTheme, setTheme])
+
+  useEffect(() => {
+    if (!activeTheme) {
+      applyThemeCSS(null)
+      return
+    }
+    let cancelled = false
+    readThemeCss(activeTheme, workspacePath).then((css) => {
+      if (!cancelled) applyThemeCSS(css)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [activeTheme, workspacePath])
+
   return <>{children}</>
 }

--- a/src/lib/fs/read.ts
+++ b/src/lib/fs/read.ts
@@ -17,6 +17,12 @@ export const readDirAppData = async (path: string) => {
   })
 }
 
+export const readAppData = async (path: string) => {
+  return readTextFile(path, {
+    baseDir: BaseDirectory.AppData,
+  })
+}
+
 export const readJson = async <T = unknown>(path: string) => {
   return read(path).then((data) => JSON.parse(data) as T)
 }

--- a/src/lib/settings/settings.service.ts
+++ b/src/lib/settings/settings.service.ts
@@ -86,6 +86,7 @@ export function createScope<TSchema extends z.ZodObject>(
   return create<ScopeStore<Data>>()((set) => ({
     ...def.defaults,
     _initialized: false,
+    workspacePath: null,
     workspaceDelta: {} as Partial<Data>,
 
     init: async (workspacePath: string) => {
@@ -119,7 +120,7 @@ export function createScope<TSchema extends z.ZodObject>(
       const workspaceDelta = await loadWorkspaceDelta(workspacePath)
       const effective = resolveSettings(globalData, workspaceDelta)
 
-      set({ ...effective, workspaceDelta, _initialized: true } as Partial<ScopeStore<Data>>)
+      set({ ...effective, workspaceDelta, _initialized: true, workspacePath } as Partial<ScopeStore<Data>>)
     },
 
     update: async (patch) => {

--- a/src/lib/settings/settings.types.ts
+++ b/src/lib/settings/settings.types.ts
@@ -15,6 +15,7 @@ export interface PersistedScope<T> {
 
 export type ScopeStore<T> = T & {
   _initialized: boolean
+  workspacePath: string | null
   workspaceDelta: Partial<T>
   init: (workspacePath: string) => Promise<void>
   update: (patch: Partial<T>) => Promise<void>

--- a/src/lib/themes/service/index.ts
+++ b/src/lib/themes/service/index.ts
@@ -1,1 +1,2 @@
 export * from './load-themes'
+export * from './read-theme-css'

--- a/src/lib/themes/service/read-theme-css.test.ts
+++ b/src/lib/themes/service/read-theme-css.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readThemeCss } from './read-theme-css'
+
+const { mockExists, mockExistsAppData, mockRead, mockReadAppData } = vi.hoisted(() => ({
+  mockExists: vi.fn(),
+  mockExistsAppData: vi.fn(),
+  mockRead: vi.fn(),
+  mockReadAppData: vi.fn(),
+}))
+
+vi.mock('@/lib/fs', () => ({
+  exists: mockExists,
+  existsAppData: mockExistsAppData,
+  read: mockRead,
+  readAppData: mockReadAppData,
+}))
+
+const WORKSPACE = 'nemos-app/my-workspace'
+
+describe('readThemeCss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null when theme is not found anywhere', async () => {
+    mockExists.mockResolvedValue(false)
+    mockExistsAppData.mockResolvedValue(false)
+
+    expect(await readThemeCss('missing', WORKSPACE)).toBeNull()
+  })
+
+  it('reads from workspace when theme.css exists there', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockResolvedValue('.ws { color: blue }')
+
+    const result = await readThemeCss('my-theme', WORKSPACE)
+
+    expect(result).toBe('.ws { color: blue }')
+    expect(mockRead).toHaveBeenCalledWith(
+      `${WORKSPACE}/.config/themes/my-theme/theme.css`,
+    )
+    expect(mockReadAppData).not.toHaveBeenCalled()
+  })
+
+  it('falls back to global when not found in workspace', async () => {
+    mockExists.mockResolvedValue(false)
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockResolvedValue('.global { color: red }')
+
+    const result = await readThemeCss('my-theme', WORKSPACE)
+
+    expect(result).toBe('.global { color: red }')
+    expect(mockReadAppData).toHaveBeenCalledWith('themes/my-theme/theme.css')
+  })
+
+  it('prefers workspace over global on ID collision', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockResolvedValue('.ws {}')
+    mockExistsAppData.mockResolvedValue(true)
+
+    const result = await readThemeCss('shared', WORKSPACE)
+
+    expect(result).toBe('.ws {}')
+    expect(mockReadAppData).not.toHaveBeenCalled()
+  })
+
+  it('skips workspace check when workspaceFsPath is null', async () => {
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockResolvedValue('.global {}')
+
+    const result = await readThemeCss('my-theme', null)
+
+    expect(result).toBe('.global {}')
+    expect(mockExists).not.toHaveBeenCalled()
+  })
+
+  it('returns null when workspaceFsPath is null and global not found', async () => {
+    mockExistsAppData.mockResolvedValue(false)
+
+    expect(await readThemeCss('my-theme', null)).toBeNull()
+  })
+
+  it('falls back to global when workspace read throws', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockRejectedValue(new Error('io error'))
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockResolvedValue('.global {}')
+
+    const result = await readThemeCss('my-theme', WORKSPACE)
+
+    expect(result).toBe('.global {}')
+  })
+
+  it('returns null without throwing when both reads fail', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockRejectedValue(new Error('io error'))
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockRejectedValue(new Error('io error'))
+
+    await expect(readThemeCss('my-theme', WORKSPACE)).resolves.toBeNull()
+  })
+})

--- a/src/lib/themes/service/read-theme-css.ts
+++ b/src/lib/themes/service/read-theme-css.ts
@@ -1,0 +1,23 @@
+import { THEMES_DIR, WORKSPACE_THEMES_DIR } from '@/config/constants'
+import { exists, existsAppData, read, readAppData } from '@/lib/fs'
+
+export const readThemeCss = async (
+  themeId: string,
+  workspaceFsPath: string | null,
+): Promise<string | null> => {
+  if (workspaceFsPath) {
+    const wsPath = `${workspaceFsPath}/${WORKSPACE_THEMES_DIR}/${themeId}/theme.css`
+    try {
+      if (await exists(wsPath)) return await read(wsPath)
+    } catch {
+      // Ignore errors and fallback to global themes
+    }
+  }
+  const globalPath = `${THEMES_DIR}/${themeId}/theme.css`
+  try {
+    if (await existsAppData(globalPath)) return await readAppData(globalPath)
+  } catch {
+    // Ignore errors and return null
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- Extends `ThemeProvider` to read a custom theme's CSS from disk and inject it as a `<style data-nemos-theme>` tag after the app's base styles
- Resolves the active theme CSS from workspace (`.config/themes/<id>/theme.css`) first, falling back to global AppData (`themes/<id>/theme.css`)
- Switching themes replaces the tag; switching to Default (`null`) removes it; missing theme IDs fall back to `null` silently

## Changes

- `src/lib/fs/read.ts` — adds `readAppData` (AppData base dir reader)
- `src/lib/settings/settings.types.ts` + `settings.service.ts` — exposes `workspacePath: string | null` on `ScopeStore<T>` so `ThemeProvider` can reactively re-inject CSS on workspace switch
- `src/lib/themes/service/read-theme-css.ts` — new service function; workspace wins on ID collision
- `src/components/providers/ThemeProvider.tsx` — adds `applyThemeCSS` helper + effect with cancellation guard to prevent stale reads

## Test plan

- [x] All existing tests pass (`pnpm test`)
- [x] 8 new unit tests for `readThemeCss` covering: not found, workspace hit, global fallback, collision priority, null workspace path, read errors
- [ ] Manually set a valid `activeTheme` ID and confirm the `<style data-nemos-theme>` tag appears in DevTools
- [ ] Switch themes and confirm the tag is replaced (no duplicates)
- [ ] Set `activeTheme` to `null` and confirm the tag is removed
- [ ] Set a non-existent theme ID and confirm no tag / no error
- [ ] Toggle light/dark while a custom theme is active and confirm both work independently

Closes #12