### PR TITLE
feat: theme picker UI in Appearance settings

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,9 @@
       "allow": [
         {
           "path": "$DOCUMENT/**"
+        },
+        {
+          "path": "$APPDATA/**"
         }
       ]
     },
@@ -45,6 +48,9 @@
       "allow": [
         {
           "path": "$DOCUMENT/**"
+        },
+        {
+          "path": "$APPDATA/**"
         }
       ]
     },
@@ -53,6 +59,9 @@
       "allow": [
         {
           "path": "$DOCUMENT/**"
+        },
+        {
+          "path": "$APPDATA/**"
         }
       ]
     },

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -1,11 +1,23 @@
 import { MonitorCog, Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Field, FieldContent, FieldLabel } from '@/components/ui/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import type { Theme } from '@/lib/settings'
 import { useAppearanceSettings } from '@/lib/settings'
+import { loadThemes } from '@/lib/themes/service/load-themes'
+import type { ThemeDescriptor } from '@/lib/themes/theme.types'
 import { cn } from '@/lib/utils'
 import { OverrideIndicator } from '../OverrideIndicator'
+
+const DEFAULT_THEME = '__default__'
 
 const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
   { value: 'light', label: 'Light', icon: Sun },
@@ -16,16 +28,32 @@ const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
 export const AppearanceSection = () => {
   const theme = useAppearanceSettings((s) => s.theme)
   const autoSyncTheme = useAppearanceSettings((s) => s.autoSyncTheme)
+  const activeTheme = useAppearanceSettings((s) => s.activeTheme)
+  const workspacePath = useAppearanceSettings((s) => s.workspacePath)
   const update = useAppearanceSettings((s) => s.update)
   const revertKey = useAppearanceSettings((s) => s.revertKey)
   const workspaceDelta = useAppearanceSettings((s) => s.workspaceDelta)
 
+  const [availableThemes, setAvailableThemes] = useState<ThemeDescriptor[]>([])
+
+  useEffect(() => {
+    if (!workspacePath) return
+    loadThemes(workspacePath)
+      .then(setAvailableThemes)
+      .catch((e) => console.error('Failed to load themes', e))
+  }, [workspacePath])
+
   const hasAutoSyncThemeOrThemeDelta =
     workspaceDelta.autoSyncTheme !== undefined ||
     workspaceDelta.theme !== undefined
+  const hasActiveThemeDelta = workspaceDelta.activeTheme !== undefined
 
   const handleAutoSyncThemeChange = (checked: boolean) => {
     update({ autoSyncTheme: theme === 'system' ? checked : false })
+  }
+
+  const handleThemeChange = (value: string) => {
+    update({ activeTheme: value === DEFAULT_THEME ? null : value })
   }
 
   return (
@@ -77,6 +105,32 @@ export const AppearanceSection = () => {
               revertKey('autoSyncTheme')
             }}
           />
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldLabel>Custom theme</FieldLabel>
+          </FieldContent>
+          <Select
+            value={activeTheme ?? DEFAULT_THEME}
+            onValueChange={handleThemeChange}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DEFAULT_THEME}>Default</SelectItem>
+              {availableThemes.map((t) => (
+                <SelectItem key={t.id} value={t.id}>
+                  {t.displayName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        {hasActiveThemeDelta && (
+          <OverrideIndicator onRevert={() => revertKey('activeTheme')} />
         )}
       </div>
     </div>

--- a/src/lib/themes/service/load-themes.ts
+++ b/src/lib/themes/service/load-themes.ts
@@ -16,7 +16,10 @@ const loadGlobalThemes = async (): Promise<ThemeDescriptor[]> => {
       .map(async (e) => {
         const hasCss = await existsAppData(`${THEMES_DIR}/${e.name}/theme.css`)
         if (!hasCss) return null
-        return { id: e.name, displayName: toDisplayName(e.name) } satisfies ThemeDescriptor
+        return {
+          id: e.name,
+          displayName: toDisplayName(e.name),
+        } satisfies ThemeDescriptor
       }),
   )
   return descriptors.filter((d): d is ThemeDescriptor => d !== null)
@@ -38,7 +41,10 @@ const loadWorkspaceThemes = async (
       .map(async (e) => {
         const hasCss = await exists(`${themesPath}/${e.name}/theme.css`)
         if (!hasCss) return null
-        return { id: e.name, displayName: toDisplayName(e.name) } satisfies ThemeDescriptor
+        return {
+          id: e.name,
+          displayName: toDisplayName(e.name),
+        } satisfies ThemeDescriptor
       }),
   )
   return descriptors.filter((d): d is ThemeDescriptor => d !== null)


### PR DESCRIPTION
## Summary

- Adds a **Custom theme** Select dropdown to the Appearance settings section, wired to `activeTheme` in the `AppearanceSettings` scope
- Scans global (`$APPDATA/themes/`) and workspace (`.config/themes/`) theme directories on section open via `loadThemes`; discovered themes appear sorted alphabetically below a permanent "Default" entry
- Selecting a theme writes `activeTheme` to workspace settings; the existing `ThemeProvider` reacts and injects the CSS immediately with no restart required
- Selecting "Default" sets `activeTheme` to `null`, removing injected CSS
- Override indicator shown when `activeTheme` has a workspace-level override, with revert-to-global action
- Extends `fs:allow-read-text-file`, `fs:allow-exists`, and `fs:allow-read-dir` capabilities to include `$APPDATA/**` so global themes can be discovered

Closes #13

## Test plan

- [x] Open Appearance settings — Custom theme picker shows "Default" selected
- [x] With no custom themes installed, only "Default" appears in the dropdown
- [x] Drop a valid theme folder (containing `theme.css`) into `%APPDATA%\com.nemos.app\themes\`, reopen Appearance — new theme appears in the picker
- [x] Select the theme — CSS is injected immediately, no restart required
- [x] Toggle Light/Dark — custom theme responds correctly to both modes
- [x] Select "Default" — injected CSS is removed, app returns to default styling
- [x] Set a workspace-specific theme — override indicator (amber dot) appears
- [x] Click the revert icon — `activeTheme` reverts to global value
- [x] Light/dark/system toggle and auto-sync are unaffected