### PR TITLE
feat(snippets): snippet service layer — load-css-snippets and read-snippet-css

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -8,3 +8,5 @@ export const WORKSPACE_CONFIG_DIR = '.config'
 export const WORKSPACE_SETTINGS_FILE = `${WORKSPACE_CONFIG_DIR}/${SETTINGS_FILE}`
 export const THEMES_DIR = 'themes'
 export const WORKSPACE_THEMES_DIR = `${WORKSPACE_CONFIG_DIR}/${THEMES_DIR}`
+export const SNIPPETS_DIR = 'snippets'
+export const WORKSPACE_SNIPPETS_DIR = `${WORKSPACE_CONFIG_DIR}/snippets`

--- a/src/lib/themes/service/index.ts
+++ b/src/lib/themes/service/index.ts
@@ -1,2 +1,4 @@
+export * from './load-css-snippets'
 export * from './load-themes'
+export * from './read-snippet-css'
 export * from './read-theme-css'

--- a/src/lib/themes/service/load-css-snippets.test.ts
+++ b/src/lib/themes/service/load-css-snippets.test.ts
@@ -11,7 +11,12 @@ vi.mock('@/lib/fs', () => ({
   readDirAppData: mockReadDirAppData,
 }))
 
-const file = (name: string) => ({ name, isDirectory: false, isFile: true, isSymlink: false })
+const file = (name: string) => ({
+  name,
+  isDirectory: false,
+  isFile: true,
+  isSymlink: false,
+})
 const WORKSPACE = 'nemos-app/my-workspace'
 
 describe('loadCssSnippets', () => {
@@ -42,24 +47,39 @@ describe('loadCssSnippets', () => {
 
     const result = await loadCssSnippets(WORKSPACE)
     expect(result.globalSnippets).toEqual([])
-    expect(result.workspaceSnippets).toEqual([{ id: 'my-snippet', displayName: 'My Snippet' }])
+    expect(result.workspaceSnippets).toEqual([
+      { id: 'my-snippet', displayName: 'My Snippet' },
+    ])
   })
 
   it('ignores non-.css files', async () => {
     mockReadDirAppData.mockResolvedValue([
       file('valid.css'),
-      { name: 'readme.txt', isDirectory: false, isFile: true, isSymlink: false },
+      {
+        name: 'readme.txt',
+        isDirectory: false,
+        isFile: true,
+        isSymlink: false,
+      },
       { name: 'theme', isDirectory: true, isFile: false, isSymlink: false },
     ])
     mockReadDir.mockResolvedValue([])
 
     const result = await loadCssSnippets(WORKSPACE)
-    expect(result.globalSnippets).toEqual([{ id: 'valid', displayName: 'Valid' }])
+    expect(result.globalSnippets).toEqual([
+      { id: 'valid', displayName: 'Valid' },
+    ])
   })
 
   it('returns both lists independently without merging', async () => {
-    mockReadDirAppData.mockResolvedValue([file('shared.css'), file('global-only.css')])
-    mockReadDir.mockResolvedValue([file('shared.css'), file('workspace-only.css')])
+    mockReadDirAppData.mockResolvedValue([
+      file('shared.css'),
+      file('global-only.css'),
+    ])
+    mockReadDir.mockResolvedValue([
+      file('shared.css'),
+      file('workspace-only.css'),
+    ])
 
     const result = await loadCssSnippets(WORKSPACE)
     expect(result.globalSnippets).toHaveLength(2)

--- a/src/lib/themes/service/load-css-snippets.test.ts
+++ b/src/lib/themes/service/load-css-snippets.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadCssSnippets } from './load-css-snippets'
+
+const { mockReadDir, mockReadDirAppData } = vi.hoisted(() => ({
+  mockReadDir: vi.fn(),
+  mockReadDirAppData: vi.fn(),
+}))
+
+vi.mock('@/lib/fs', () => ({
+  readDir: mockReadDir,
+  readDirAppData: mockReadDirAppData,
+}))
+
+const file = (name: string) => ({ name, isDirectory: false, isFile: true, isSymlink: false })
+const WORKSPACE = 'nemos-app/my-workspace'
+
+describe('loadCssSnippets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty lists when both snippet directories do not exist', async () => {
+    mockReadDirAppData.mockRejectedValue(new Error('not found'))
+    mockReadDir.mockRejectedValue(new Error('not found'))
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result).toEqual({ globalSnippets: [], workspaceSnippets: [] })
+  })
+
+  it('returns global snippets when workspace directory does not exist', async () => {
+    mockReadDirAppData.mockResolvedValue([file('nord.css')])
+    mockReadDir.mockRejectedValue(new Error('not found'))
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result.globalSnippets).toEqual([{ id: 'nord', displayName: 'Nord' }])
+    expect(result.workspaceSnippets).toEqual([])
+  })
+
+  it('returns workspace snippets when global directory does not exist', async () => {
+    mockReadDirAppData.mockRejectedValue(new Error('not found'))
+    mockReadDir.mockResolvedValue([file('my-snippet.css')])
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result.globalSnippets).toEqual([])
+    expect(result.workspaceSnippets).toEqual([{ id: 'my-snippet', displayName: 'My Snippet' }])
+  })
+
+  it('ignores non-.css files', async () => {
+    mockReadDirAppData.mockResolvedValue([
+      file('valid.css'),
+      { name: 'readme.txt', isDirectory: false, isFile: true, isSymlink: false },
+      { name: 'theme', isDirectory: true, isFile: false, isSymlink: false },
+    ])
+    mockReadDir.mockResolvedValue([])
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result.globalSnippets).toEqual([{ id: 'valid', displayName: 'Valid' }])
+  })
+
+  it('returns both lists independently without merging', async () => {
+    mockReadDirAppData.mockResolvedValue([file('shared.css'), file('global-only.css')])
+    mockReadDir.mockResolvedValue([file('shared.css'), file('workspace-only.css')])
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result.globalSnippets).toHaveLength(2)
+    expect(result.workspaceSnippets).toHaveLength(2)
+    expect(result.globalSnippets.map((s) => s.id)).toContain('shared')
+    expect(result.workspaceSnippets.map((s) => s.id)).toContain('shared')
+  })
+
+  it('derives display name from filename using toDisplayName', async () => {
+    mockReadDirAppData.mockResolvedValue([file('my-dracula-theme.css')])
+    mockReadDir.mockResolvedValue([])
+
+    const result = await loadCssSnippets(WORKSPACE)
+    expect(result.globalSnippets[0].displayName).toBe('My Dracula Theme')
+  })
+})

--- a/src/lib/themes/service/load-css-snippets.ts
+++ b/src/lib/themes/service/load-css-snippets.ts
@@ -38,7 +38,10 @@ const loadWorkspaceSnippets = async (
 
 export const loadCssSnippets = async (
   workspaceFsPath: string,
-): Promise<{ globalSnippets: SnippetDescriptor[]; workspaceSnippets: SnippetDescriptor[] }> => {
+): Promise<{
+  globalSnippets: SnippetDescriptor[]
+  workspaceSnippets: SnippetDescriptor[]
+}> => {
   const [globalSnippets, workspaceSnippets] = await Promise.all([
     loadGlobalSnippets(),
     loadWorkspaceSnippets(workspaceFsPath),

--- a/src/lib/themes/service/load-css-snippets.ts
+++ b/src/lib/themes/service/load-css-snippets.ts
@@ -1,0 +1,47 @@
+import { SNIPPETS_DIR, WORKSPACE_SNIPPETS_DIR } from '@/config/constants'
+import { readDir, readDirAppData } from '@/lib/fs'
+import type { SnippetDescriptor } from '../theme.types'
+import { toDisplayName } from '../utils'
+
+const loadGlobalSnippets = async (): Promise<SnippetDescriptor[]> => {
+  let entries: Awaited<ReturnType<typeof readDirAppData>>
+  try {
+    entries = await readDirAppData(SNIPPETS_DIR)
+  } catch {
+    return []
+  }
+  return entries
+    .filter((e) => e.isFile && e.name?.endsWith('.css'))
+    .map((e) => {
+      const id = e.name!.replace(/\.css$/, '')
+      return { id, displayName: toDisplayName(id) } satisfies SnippetDescriptor
+    })
+}
+
+const loadWorkspaceSnippets = async (
+  workspaceFsPath: string,
+): Promise<SnippetDescriptor[]> => {
+  const snippetsPath = `${workspaceFsPath}/${WORKSPACE_SNIPPETS_DIR}`
+  let entries: Awaited<ReturnType<typeof readDir>>
+  try {
+    entries = await readDir(snippetsPath)
+  } catch {
+    return []
+  }
+  return entries
+    .filter((e) => e.isFile && e.name?.endsWith('.css'))
+    .map((e) => {
+      const id = e.name!.replace(/\.css$/, '')
+      return { id, displayName: toDisplayName(id) } satisfies SnippetDescriptor
+    })
+}
+
+export const loadCssSnippets = async (
+  workspaceFsPath: string,
+): Promise<{ globalSnippets: SnippetDescriptor[]; workspaceSnippets: SnippetDescriptor[] }> => {
+  const [globalSnippets, workspaceSnippets] = await Promise.all([
+    loadGlobalSnippets(),
+    loadWorkspaceSnippets(workspaceFsPath),
+  ])
+  return { globalSnippets, workspaceSnippets }
+}

--- a/src/lib/themes/service/load-themes.test.ts
+++ b/src/lib/themes/service/load-themes.test.ts
@@ -16,7 +16,12 @@ vi.mock('@/lib/fs', () => ({
   existsAppData: mockExistsAppData,
 }))
 
-const dir = (name: string) => ({ name, isDirectory: true, isFile: false, isSymlink: false })
+const dir = (name: string) => ({
+  name,
+  isDirectory: true,
+  isFile: false,
+  isSymlink: false,
+})
 const WORKSPACE = 'nemos-app/my-workspace'
 
 describe('loadThemes', () => {
@@ -54,7 +59,7 @@ describe('loadThemes', () => {
     mockReadDirAppData.mockResolvedValue([dir('no-css'), dir('has-css')])
     mockExistsAppData
       .mockResolvedValueOnce(false) // no-css/theme.css
-      .mockResolvedValueOnce(true)  // has-css/theme.css
+      .mockResolvedValueOnce(true) // has-css/theme.css
     mockReadDir.mockResolvedValue([])
 
     const result = await loadThemes(WORKSPACE)
@@ -79,7 +84,10 @@ describe('loadThemes', () => {
     mockExists.mockResolvedValue(true)
 
     const result = await loadThemes(WORKSPACE)
-    expect(result.map((t) => t.displayName)).toEqual(['Apple Theme', 'Zebra Theme'])
+    expect(result.map((t) => t.displayName)).toEqual([
+      'Apple Theme',
+      'Zebra Theme',
+    ])
   })
 
   it('derives display name correctly from folder name', async () => {

--- a/src/lib/themes/service/read-snippet-css.test.ts
+++ b/src/lib/themes/service/read-snippet-css.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readSnippetCss } from './read-snippet-css'
+
+const { mockExists, mockExistsAppData, mockRead, mockReadAppData } = vi.hoisted(
+  () => ({
+    mockExists: vi.fn(),
+    mockExistsAppData: vi.fn(),
+    mockRead: vi.fn(),
+    mockReadAppData: vi.fn(),
+  }),
+)
+
+vi.mock('@/lib/fs', () => ({
+  exists: mockExists,
+  existsAppData: mockExistsAppData,
+  read: mockRead,
+  readAppData: mockReadAppData,
+}))
+
+const WORKSPACE = 'nemos-app/my-workspace'
+
+describe('readSnippetCss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null when global file does not exist', async () => {
+    mockExistsAppData.mockResolvedValue(false)
+
+    expect(await readSnippetCss('global', 'my-snippet.css', null)).toBeNull()
+  })
+
+  it('returns CSS content for an existing global file', async () => {
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockResolvedValue('.global { color: red }')
+
+    const result = await readSnippetCss('global', 'my-snippet.css', null)
+
+    expect(result).toBe('.global { color: red }')
+    expect(mockReadAppData).toHaveBeenCalledWith('snippets/my-snippet.css')
+  })
+
+  it('returns CSS content for an existing workspace file', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockResolvedValue('.ws { color: blue }')
+
+    const result = await readSnippetCss(
+      'workspace',
+      'my-snippet.css',
+      WORKSPACE,
+    )
+
+    expect(result).toBe('.ws { color: blue }')
+    expect(mockRead).toHaveBeenCalledWith(
+      `${WORKSPACE}/.config/snippets/my-snippet.css`,
+    )
+  })
+
+  it('returns null when workspace file does not exist', async () => {
+    mockExists.mockResolvedValue(false)
+
+    expect(
+      await readSnippetCss('workspace', 'my-snippet.css', WORKSPACE),
+    ).toBeNull()
+  })
+
+  it('returns null when workspace scope requested but workspaceFsPath is null', async () => {
+    expect(await readSnippetCss('workspace', 'my-snippet.css', null)).toBeNull()
+    expect(mockExists).not.toHaveBeenCalled()
+  })
+
+  it('returns null without throwing when global read fails', async () => {
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockRejectedValue(new Error('io error'))
+
+    await expect(
+      readSnippetCss('global', 'my-snippet.css', null),
+    ).resolves.toBeNull()
+  })
+
+  it('returns null without throwing when workspace read fails', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockRejectedValue(new Error('io error'))
+
+    await expect(
+      readSnippetCss('workspace', 'my-snippet.css', WORKSPACE),
+    ).resolves.toBeNull()
+  })
+
+  it('global and workspace scopes are fully independent', async () => {
+    mockExists.mockResolvedValue(true)
+    mockRead.mockResolvedValue('.ws {}')
+    mockExistsAppData.mockResolvedValue(true)
+    mockReadAppData.mockResolvedValue('.global {}')
+
+    const wsResult = await readSnippetCss('workspace', 'shared.css', WORKSPACE)
+    const globalResult = await readSnippetCss('global', 'shared.css', WORKSPACE)
+
+    expect(wsResult).toBe('.ws {}')
+    expect(globalResult).toBe('.global {}')
+  })
+})

--- a/src/lib/themes/service/read-snippet-css.ts
+++ b/src/lib/themes/service/read-snippet-css.ts
@@ -1,0 +1,27 @@
+import { SNIPPETS_DIR, WORKSPACE_SNIPPETS_DIR } from '@/config/constants'
+import { exists, existsAppData, read, readAppData } from '@/lib/fs'
+
+export const readSnippetCss = async (
+  scope: 'global' | 'workspace',
+  filename: string,
+  workspaceFsPath: string | null,
+): Promise<string | null> => {
+  if (scope === 'global') {
+    const path = `${SNIPPETS_DIR}/${filename}`
+    try {
+      if (await existsAppData(path)) return await readAppData(path)
+    } catch {
+      // ignore
+    }
+    return null
+  }
+
+  if (!workspaceFsPath) return null
+  const path = `${workspaceFsPath}/${WORKSPACE_SNIPPETS_DIR}/${filename}`
+  try {
+    if (await exists(path)) return await read(path)
+  } catch {
+    // ignore
+  }
+  return null
+}

--- a/src/lib/themes/service/read-theme-css.test.ts
+++ b/src/lib/themes/service/read-theme-css.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { readThemeCss } from './read-theme-css'
 
-const { mockExists, mockExistsAppData, mockRead, mockReadAppData } = vi.hoisted(() => ({
-  mockExists: vi.fn(),
-  mockExistsAppData: vi.fn(),
-  mockRead: vi.fn(),
-  mockReadAppData: vi.fn(),
-}))
+const { mockExists, mockExistsAppData, mockRead, mockReadAppData } = vi.hoisted(
+  () => ({
+    mockExists: vi.fn(),
+    mockExistsAppData: vi.fn(),
+    mockRead: vi.fn(),
+    mockReadAppData: vi.fn(),
+  }),
+)
 
 vi.mock('@/lib/fs', () => ({
   exists: mockExists,

--- a/src/lib/themes/theme.types.ts
+++ b/src/lib/themes/theme.types.ts
@@ -2,3 +2,8 @@ export interface ThemeDescriptor {
   id: string
   displayName: string
 }
+
+export interface SnippetDescriptor {
+  id: string
+  displayName: string
+}


### PR DESCRIPTION
## Summary

- Adds `SnippetDescriptor` type and `SNIPPETS_DIR` / `WORKSPACE_SNIPPETS_DIR` constants
- Implements `loadCssSnippets` — scans global and workspace `.css` files independently, returns separate lists (no merging)
- Implements `readSnippetCss` — scope-based (`global` | `workspace`), accepts full `filename.css`, fully independent between scopes
- Full test coverage (6 tests for `load-css-snippets`, 8 for `read-snippet-css`) following the existing theme test patterns

Closes #19

## Test plan

- [ ] `pnpm vitest run src/lib/themes` — all 43 tests pass