### PR TITLE
feat(snippets): add disabledGlobalSnippets and disabledWorkspaceSnippets to AppearanceSettings

### DIFF
--- a/src/lib/settings/scopes/appearance.scope.test.ts
+++ b/src/lib/settings/scopes/appearance.scope.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { AppearanceSettings } from './appearance.scope'
+
+const validV1 = {
+  theme: 'system' as const,
+  autoSyncTheme: true,
+  activeTheme: null,
+}
+
+describe('AppearanceSettings schema', () => {
+  it('disabledGlobalSnippets defaults to [] when absent', () => {
+    const result = AppearanceSettings.parse(validV1)
+    expect(result.disabledGlobalSnippets).toEqual([])
+  })
+
+  it('disabledWorkspaceSnippets defaults to [] when absent', () => {
+    const result = AppearanceSettings.parse(validV1)
+    expect(result.disabledWorkspaceSnippets).toEqual([])
+  })
+})

--- a/src/lib/settings/scopes/appearance.scope.ts
+++ b/src/lib/settings/scopes/appearance.scope.ts
@@ -12,6 +12,8 @@ export const AppearanceSettings = z.object({
   theme: z.enum(Themes),
   autoSyncTheme: z.boolean(),
   activeTheme: z.string().nullable().default(null),
+  disabledGlobalSnippets: z.array(z.string()).default([]),
+  disabledWorkspaceSnippets: z.array(z.string()).default([]),
 })
 export type AppearanceSettings = z.infer<typeof AppearanceSettings>
 
@@ -19,5 +21,11 @@ export const useAppearanceSettings = createScope({
   key: 'appearance',
   version: 1,
   schema: AppearanceSettings,
-  defaults: { theme: Themes.SYSTEM, autoSyncTheme: true, activeTheme: null },
+  defaults: {
+    theme: Themes.SYSTEM,
+    autoSyncTheme: true,
+    activeTheme: null,
+    disabledGlobalSnippets: [],
+    disabledWorkspaceSnippets: [],
+  },
 })


### PR DESCRIPTION
## Summary

- Adds `disabledGlobalSnippets: string[]` to `AppearanceSettings` Zod schema, defaulting to `[]`
- Adds `disabledWorkspaceSnippets: string[]` to `AppearanceSettings` Zod schema, defaulting to `[]`
- Adds corresponding defaults in `useAppearanceSettings` scope definition
- Covers both new fields with schema-default tests in `appearance.scope.test.ts`

No version bump or migration needed — versioning has not shipped to real users yet.

Closes #20

## Test plan

- [x] `pnpm vitest run` — all tests pass
- [x] `AppearanceSettings.parse()` with v1-shaped data returns `disabledGlobalSnippets: []` and `disabledWorkspaceSnippets: []`