### PR TITLE
feat(snippets): CSS injection — SnippetsProvider

### DIFF
--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -1,4 +1,5 @@
 import { SettingsProvider } from './SettingsProvider'
+import { SnippetsProvider } from './SnippetsProvider'
 import { ThemeProvider } from './ThemeProvider'
 
 interface Props {
@@ -8,7 +9,9 @@ interface Props {
 export const Providers = ({ children }: Props) => {
   return (
     <SettingsProvider>
-      <ThemeProvider>{children}</ThemeProvider>
+      <ThemeProvider>
+        <SnippetsProvider>{children}</SnippetsProvider>
+      </ThemeProvider>
     </SettingsProvider>
   )
 }

--- a/src/components/providers/SnippetsProvider.tsx
+++ b/src/components/providers/SnippetsProvider.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+import { useAppearanceSettings } from '@/lib/settings'
+import { filterEnabled, loadCssSnippets, readSnippetCss } from '@/lib/themes'
+
+const GLOBAL_ATTR = 'data-nemos-snippet-global'
+const WORKSPACE_ATTR = 'data-nemos-snippet-workspace'
+
+function injectSnippetStyle(attr: string, id: string, css: string) {
+  const existing = document.querySelector(`[${attr}="${id}"]`)
+  if (existing) {
+    existing.textContent = css
+    return
+  }
+  const style = document.createElement('style')
+  style.setAttribute(attr, id)
+  style.textContent = css
+  document.head.appendChild(style)
+}
+
+function removeAllSnippetStyles(attr: string) {
+  document.querySelectorAll(`[${attr}]`).forEach((el) => el.remove())
+}
+
+export const SnippetsProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const workspacePath = useAppearanceSettings((s) => s.workspacePath)
+  const disabledGlobal = useAppearanceSettings((s) => s.disabledGlobalSnippets)
+  const disabledWorkspace = useAppearanceSettings(
+    (s) => s.disabledWorkspaceSnippets,
+  )
+
+  useEffect(() => {
+    if (!workspacePath) return
+    let cancelled = false
+
+    removeAllSnippetStyles(GLOBAL_ATTR)
+    removeAllSnippetStyles(WORKSPACE_ATTR)
+
+    loadCssSnippets(workspacePath).then(
+      async ({ globalSnippets, workspaceSnippets }) => {
+        if (cancelled) return
+
+        const enabledGlobal = filterEnabled(globalSnippets, disabledGlobal)
+        const enabledWorkspace = filterEnabled(
+          workspaceSnippets,
+          disabledWorkspace,
+        )
+
+        for (const snippet of enabledGlobal) {
+          if (cancelled) return
+          const css = await readSnippetCss(
+            'global',
+            `${snippet.id}.css`,
+            workspacePath,
+          )
+          if (cancelled || !css) continue
+          injectSnippetStyle(GLOBAL_ATTR, snippet.id, css)
+        }
+
+        for (const snippet of enabledWorkspace) {
+          if (cancelled) return
+          const css = await readSnippetCss(
+            'workspace',
+            `${snippet.id}.css`,
+            workspacePath,
+          )
+          if (cancelled || !css) continue
+          injectSnippetStyle(WORKSPACE_ATTR, snippet.id, css)
+        }
+      },
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [workspacePath, disabledGlobal, disabledWorkspace])
+
+  return <>{children}</>
+}

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -1,1 +1,2 @@
 export * from './Providers'
+export * from './SnippetsProvider'

--- a/src/lib/settings/scopes/appearance.scope.ts
+++ b/src/lib/settings/scopes/appearance.scope.ts
@@ -12,6 +12,8 @@ export const AppearanceSettings = z.object({
   theme: z.enum(Themes),
   autoSyncTheme: z.boolean(),
   activeTheme: z.string().nullable().default(null),
+  disabledGlobalSnippets: z.array(z.string()).default([]),
+  disabledWorkspaceSnippets: z.array(z.string()).default([]),
 })
 export type AppearanceSettings = z.infer<typeof AppearanceSettings>
 
@@ -19,5 +21,11 @@ export const useAppearanceSettings = createScope({
   key: 'appearance',
   version: 1,
   schema: AppearanceSettings,
-  defaults: { theme: Themes.SYSTEM, autoSyncTheme: true, activeTheme: null },
+  defaults: {
+    theme: Themes.SYSTEM,
+    autoSyncTheme: true,
+    activeTheme: null,
+    disabledGlobalSnippets: [],
+    disabledWorkspaceSnippets: [],
+  },
 })

--- a/src/lib/themes/utils.test.ts
+++ b/src/lib/themes/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { AppearanceSettings } from '@/lib/settings'
-import type { ThemeDescriptor } from './theme.types'
-import { mergeThemes, toDisplayName } from './utils'
+import type { SnippetDescriptor, ThemeDescriptor } from './theme.types'
+import { filterEnabled, mergeThemes, toDisplayName } from './utils'
 
 describe('toDisplayName', () => {
   it('replaces hyphens with spaces and title-cases each word', () => {
@@ -22,7 +22,10 @@ describe('toDisplayName', () => {
 })
 
 describe('mergeThemes', () => {
-  const g = (id: string): ThemeDescriptor => ({ id, displayName: toDisplayName(id) })
+  const g = (id: string): ThemeDescriptor => ({
+    id,
+    displayName: toDisplayName(id),
+  })
 
   it('returns global-only themes when no workspace themes exist', () => {
     const result = mergeThemes([g('alpha'), g('beta')], [])
@@ -35,8 +38,14 @@ describe('mergeThemes', () => {
   })
 
   it('workspace entry wins on ID collision', () => {
-    const globalTheme: ThemeDescriptor = { id: 'my-theme', displayName: 'Global Name' }
-    const workspaceTheme: ThemeDescriptor = { id: 'my-theme', displayName: 'Workspace Name' }
+    const globalTheme: ThemeDescriptor = {
+      id: 'my-theme',
+      displayName: 'Global Name',
+    }
+    const workspaceTheme: ThemeDescriptor = {
+      id: 'my-theme',
+      displayName: 'Workspace Name',
+    }
     const result = mergeThemes([globalTheme], [workspaceTheme])
     expect(result).toHaveLength(1)
     expect(result[0].displayName).toBe('Workspace Name')
@@ -59,9 +68,75 @@ describe('mergeThemes', () => {
   })
 })
 
+describe('filterEnabled', () => {
+  const s = (id: string): SnippetDescriptor => ({ id, displayName: id })
+
+  it('returns empty array when snippet list is empty', () => {
+    expect(filterEnabled([], [])).toEqual([])
+  })
+
+  it('returns all snippets when disabled list is empty', () => {
+    expect(filterEnabled([s('nord'), s('dracula')], [])).toEqual([
+      s('nord'),
+      s('dracula'),
+    ])
+  })
+
+  it('excludes a snippet whose ID is in the disabled list', () => {
+    expect(filterEnabled([s('nord'), s('dracula')], ['nord'])).toEqual([
+      s('dracula'),
+    ])
+  })
+
+  it('excludes all snippets when all IDs are disabled', () => {
+    expect(
+      filterEnabled([s('nord'), s('dracula')], ['nord', 'dracula']),
+    ).toEqual([])
+  })
+
+  it('returns all snippets when disabled list contains IDs not present in the list', () => {
+    expect(filterEnabled([s('nord')], ['other'])).toEqual([s('nord')])
+  })
+})
+
+describe('AppearanceSettings schema — disabled snippets', () => {
+  it('defaults disabledGlobalSnippets to [] when field is missing', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.disabledGlobalSnippets).toEqual([])
+  })
+
+  it('defaults disabledWorkspaceSnippets to [] when field is missing', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+    })
+    expect(result.success).toBe(true)
+    if (result.success)
+      expect(result.data.disabledWorkspaceSnippets).toEqual([])
+  })
+
+  it('accepts string array for disabledGlobalSnippets', () => {
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+      disabledGlobalSnippets: ['nord', 'dracula'],
+    })
+    expect(result.success).toBe(true)
+    if (result.success)
+      expect(result.data.disabledGlobalSnippets).toEqual(['nord', 'dracula'])
+  })
+})
+
 describe('AppearanceSettings schema — activeTheme', () => {
   it('defaults activeTheme to null when field is missing', () => {
-    const result = AppearanceSettings.safeParse({ theme: 'system', autoSyncTheme: true })
+    const result = AppearanceSettings.safeParse({
+      theme: 'system',
+      autoSyncTheme: true,
+    })
     expect(result.success).toBe(true)
     if (result.success) expect(result.data.activeTheme).toBeNull()
   })

--- a/src/lib/themes/utils.ts
+++ b/src/lib/themes/utils.ts
@@ -1,9 +1,12 @@
-import type { ThemeDescriptor } from './theme.types'
+import type { SnippetDescriptor, ThemeDescriptor } from './theme.types'
 
 export const toDisplayName = (folderName: string): string =>
-  folderName
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+  folderName.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+
+export const filterEnabled = (
+  descriptors: SnippetDescriptor[],
+  disabled: string[],
+): SnippetDescriptor[] => descriptors.filter((d) => !disabled.includes(d.id))
 
 export const mergeThemes = (
   global: ThemeDescriptor[],


### PR DESCRIPTION
## Summary

Closes #21

- Re-adds `disabledGlobalSnippets` / `disabledWorkspaceSnippets` to `AppearanceSettings` schema (reverted in #26, required here)
- Adds `filterEnabled(descriptors, disabled)` pure utility to `src/lib/themes/utils.ts` with full test coverage
- Implements `SnippetsProvider` — injects `<style data-nemos-snippet-global="[id]">` tags before `<style data-nemos-snippet-workspace="[id]">` tags, re-runs on workspace change or toggle, silently skips missing files
- Registers `SnippetsProvider` inside `ThemeProvider` in the provider composition chain

## Test plan

- [x] All `filterEnabled` unit tests pass (`pnpm test`)
- [x] `AppearanceSettings` schema tests for disabled snippet fields pass
- [x] Drop a `.css` file in the global snippets folder and open a workspace — style tag appears in `<head>` with `data-nemos-snippet-global` attribute
- [x] Drop a `.css` file in the workspace snippets folder — style tag appears after the global tags
- [x] Toggle a snippet off in settings — its `<style>` tag is removed; other tags are unaffected
- [x] Toggle a snippet back on — CSS is re-read from disk and tag is reinjected
- [x] Delete a snippet file while it is enabled — app does not crash on next load