### PR TITLE
feat(snippets): Settings UI — snippet sections with toggles and folder buttons

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -108,6 +108,9 @@
         },
         {
           "path": "$DOCUMENT/**"
+        },
+        {
+          "path": "$APPDATA/**"
         }
       ]
     },

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -70,6 +70,9 @@
       "allow": [
         {
           "path": "$DOCUMENT/**"
+        },
+        {
+          "path": "$APPDATA/**"
         }
       ]
     },

--- a/src/components/providers/SnippetsProvider.tsx
+++ b/src/components/providers/SnippetsProvider.tsx
@@ -17,10 +17,6 @@ function injectSnippetStyle(attr: string, id: string, css: string) {
   document.head.appendChild(style)
 }
 
-function removeAllSnippetStyles(attr: string) {
-  document.querySelectorAll(`[${attr}]`).forEach((el) => el.remove())
-}
-
 export const SnippetsProvider = ({
   children,
 }: {
@@ -36,9 +32,6 @@ export const SnippetsProvider = ({
     if (!workspacePath) return
     let cancelled = false
 
-    removeAllSnippetStyles(GLOBAL_ATTR)
-    removeAllSnippetStyles(WORKSPACE_ATTR)
-
     loadCssSnippets(workspacePath).then(
       async ({ globalSnippets, workspaceSnippets }) => {
         if (cancelled) return
@@ -48,6 +41,9 @@ export const SnippetsProvider = ({
           workspaceSnippets,
           disabledWorkspace,
         )
+
+        const nextGlobalIds = new Set(enabledGlobal.map((s) => s.id))
+        const nextWorkspaceIds = new Set(enabledWorkspace.map((s) => s.id))
 
         for (const snippet of enabledGlobal) {
           if (cancelled) return
@@ -70,6 +66,16 @@ export const SnippetsProvider = ({
           if (cancelled || !css) continue
           injectSnippetStyle(WORKSPACE_ATTR, snippet.id, css)
         }
+
+        if (cancelled) return
+
+        document.querySelectorAll(`[${GLOBAL_ATTR}]`).forEach((el) => {
+          if (!nextGlobalIds.has(el.getAttribute(GLOBAL_ATTR)!)) el.remove()
+        })
+        document.querySelectorAll(`[${WORKSPACE_ATTR}]`).forEach((el) => {
+          if (!nextWorkspaceIds.has(el.getAttribute(WORKSPACE_ATTR)!))
+            el.remove()
+        })
       },
     )
 

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -1,7 +1,12 @@
-import { MonitorCog, Moon, Sun } from 'lucide-react'
+import { FolderOpen, MonitorCog, Moon, Sun } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { Field, FieldContent, FieldLabel } from '@/components/ui/field'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from '@/components/ui/field'
 import {
   Select,
   SelectContent,
@@ -9,11 +14,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
+import { SNIPPETS_DIR, WORKSPACE_SNIPPETS_DIR } from '@/config/constants'
+import { openAppDataPath, openPath } from '@/lib/opener'
 import type { Theme } from '@/lib/settings'
 import { useAppearanceSettings } from '@/lib/settings'
+import { loadCssSnippets, toggleSnippetId } from '@/lib/themes'
 import { loadThemes } from '@/lib/themes/service/load-themes'
-import type { ThemeDescriptor } from '@/lib/themes/theme.types'
+import type {
+  SnippetDescriptor,
+  ThemeDescriptor,
+} from '@/lib/themes/theme.types'
 import { cn } from '@/lib/utils'
 import { OverrideIndicator } from '../OverrideIndicator'
 
@@ -30,17 +42,33 @@ export const AppearanceSection = () => {
   const autoSyncTheme = useAppearanceSettings((s) => s.autoSyncTheme)
   const activeTheme = useAppearanceSettings((s) => s.activeTheme)
   const workspacePath = useAppearanceSettings((s) => s.workspacePath)
+  const disabledGlobalSnippets = useAppearanceSettings(
+    (s) => s.disabledGlobalSnippets,
+  )
+  const disabledWorkspaceSnippets = useAppearanceSettings(
+    (s) => s.disabledWorkspaceSnippets,
+  )
   const update = useAppearanceSettings((s) => s.update)
   const revertKey = useAppearanceSettings((s) => s.revertKey)
   const workspaceDelta = useAppearanceSettings((s) => s.workspaceDelta)
 
   const [availableThemes, setAvailableThemes] = useState<ThemeDescriptor[]>([])
+  const [globalSnippets, setGlobalSnippets] = useState<SnippetDescriptor[]>([])
+  const [workspaceSnippets, setWorkspaceSnippets] = useState<
+    SnippetDescriptor[]
+  >([])
 
   useEffect(() => {
     if (!workspacePath) return
     loadThemes(workspacePath)
       .then(setAvailableThemes)
       .catch((e) => console.error('Failed to load themes', e))
+    loadCssSnippets(workspacePath)
+      .then(({ globalSnippets, workspaceSnippets }) => {
+        setGlobalSnippets(globalSnippets)
+        setWorkspaceSnippets(workspaceSnippets)
+      })
+      .catch((e) => console.error('Failed to load snippets', e))
   }, [workspacePath])
 
   const hasAutoSyncThemeOrThemeDelta =
@@ -54,6 +82,18 @@ export const AppearanceSection = () => {
 
   const handleThemeChange = (value: string) => {
     update({ activeTheme: value === DEFAULT_THEME ? null : value })
+  }
+
+  const handleToggleGlobalSnippet = (id: string) => {
+    update({
+      disabledGlobalSnippets: toggleSnippetId(disabledGlobalSnippets, id),
+    })
+  }
+
+  const handleToggleWorkspaceSnippet = (id: string) => {
+    update({
+      disabledWorkspaceSnippets: toggleSnippetId(disabledWorkspaceSnippets, id),
+    })
   }
 
   return (
@@ -133,6 +173,107 @@ export const AppearanceSection = () => {
           <OverrideIndicator onRevert={() => revertKey('activeTheme')} />
         )}
       </div>
+
+      <Separator />
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <p className="font-medium text-sm">Global snippets</p>
+          <p className="text-muted-foreground text-xs">
+            CSS snippets applied across all workspaces.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs"
+          onClick={() => openAppDataPath(SNIPPETS_DIR)}
+        >
+          <FolderOpen className="size-3.5" />
+          Open folder
+        </Button>
+      </div>
+      {globalSnippets.length === 0 ? (
+        <p className="text-muted-foreground text-xs">
+          No snippets found. Add <code>.css</code> files to the global snippets
+          folder.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {globalSnippets.map((s) => (
+            <Field key={s.id} orientation="horizontal">
+              <FieldContent>
+                <FieldLabel
+                  htmlFor={`global-snippet-${s.id}`}
+                  className="text-xs"
+                >
+                  {s.displayName}
+                </FieldLabel>
+                <FieldDescription className="text-xs">
+                  {s.id}.css
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id={`global-snippet-${s.id}`}
+                checked={!disabledGlobalSnippets.includes(s.id)}
+                onCheckedChange={() => handleToggleGlobalSnippet(s.id)}
+              />
+            </Field>
+          ))}
+        </div>
+      )}
+
+      <Separator />
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <p className="font-medium text-sm">Workspace snippets</p>
+          <p className="text-muted-foreground text-xs">
+            CSS snippets applied only in this workspace.
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 text-xs"
+          onClick={() =>
+            workspacePath &&
+            openPath(`${workspacePath}/${WORKSPACE_SNIPPETS_DIR}`)
+          }
+        >
+          <FolderOpen className="size-3.5" />
+          Open folder
+        </Button>
+      </div>
+      {workspaceSnippets.length === 0 ? (
+        <p className="text-muted-foreground text-xs">
+          No snippets found. Add <code>.css</code> files to the workspace
+          snippets folder.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {workspaceSnippets.map((s) => (
+            <Field key={s.id} orientation="horizontal">
+              <FieldContent>
+                <FieldLabel
+                  htmlFor={`workspace-snippet-${s.id}`}
+                  className="text-xs"
+                >
+                  {s.displayName}
+                </FieldLabel>
+                <FieldDescription className="text-xs">
+                  {s.id}.css
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id={`workspace-snippet-${s.id}`}
+                checked={!disabledWorkspaceSnippets.includes(s.id)}
+                onCheckedChange={() => handleToggleWorkspaceSnippet(s.id)}
+              />
+            </Field>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -17,6 +17,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { SNIPPETS_DIR, WORKSPACE_SNIPPETS_DIR } from '@/config/constants'
+import { ensureDir, ensureDirAppData } from '@/lib/fs'
 import { openAppDataPath, openPath } from '@/lib/opener'
 import type { Theme } from '@/lib/settings'
 import { useAppearanceSettings } from '@/lib/settings'
@@ -187,7 +188,11 @@ export const AppearanceSection = () => {
           variant="ghost"
           size="sm"
           className="text-xs"
-          onClick={() => openAppDataPath(SNIPPETS_DIR)}
+          onClick={() =>
+            ensureDirAppData(SNIPPETS_DIR).then(() =>
+              openAppDataPath(SNIPPETS_DIR),
+            )
+          }
         >
           <FolderOpen className="size-3.5" />
           Open folder
@@ -236,10 +241,11 @@ export const AppearanceSection = () => {
           variant="ghost"
           size="sm"
           className="h-7 gap-1.5 text-xs"
-          onClick={() =>
-            workspacePath &&
-            openPath(`${workspacePath}/${WORKSPACE_SNIPPETS_DIR}`)
-          }
+          onClick={() => {
+            if (!workspacePath) return
+            const dir = `${workspacePath}/${WORKSPACE_SNIPPETS_DIR}`
+            ensureDir(dir).then(() => openPath(dir))
+          }}
         >
           <FolderOpen className="size-3.5" />
           Open folder

--- a/src/lib/fs/create.ts
+++ b/src/lib/fs/create.ts
@@ -19,3 +19,13 @@ export const createDir = async (
     recursive,
   })
 }
+
+export const createAppDataDir = async (
+  path: string,
+  { recursive = true }: { recursive?: boolean } = {},
+) => {
+  return mkdir(path, {
+    baseDir: BaseDirectory.AppData,
+    recursive,
+  })
+}

--- a/src/lib/fs/ensure-dir.ts
+++ b/src/lib/fs/ensure-dir.ts
@@ -1,5 +1,5 @@
-import { createDir } from './create'
-import { exists } from './exists'
+import { createAppDataDir, createDir } from './create'
+import { exists, existsAppData } from './exists'
 
 export const ensureDir = async (
   path: string,
@@ -7,4 +7,12 @@ export const ensureDir = async (
 ) => {
   if (await exists(path)) return
   return await createDir(path, options)
+}
+
+export const ensureDirAppData = async (
+  path: string,
+  options?: { recursive?: boolean },
+) => {
+  if (await existsAppData(path)) return
+  return await createAppDataDir(path, options)
 }

--- a/src/lib/opener/open-path.ts
+++ b/src/lib/opener/open-path.ts
@@ -1,8 +1,12 @@
-import { documentDir, join } from '@tauri-apps/api/path'
+import { appDataDir, documentDir, join } from '@tauri-apps/api/path'
 import { openPath as openPathFn } from '@tauri-apps/plugin-opener'
 
 export const openPath = async (path: string): Promise<void> => {
-  const parts = [await documentDir(), path]
-  const fullPath = await join(...parts)
+  const fullPath = await join(await documentDir(), path)
+  await openPathFn(fullPath)
+}
+
+export const openAppDataPath = async (path: string): Promise<void> => {
+  const fullPath = await join(await appDataDir(), path)
   await openPathFn(fullPath)
 }

--- a/src/lib/themes/utils.test.ts
+++ b/src/lib/themes/utils.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { AppearanceSettings } from '@/lib/settings'
 import type { SnippetDescriptor, ThemeDescriptor } from './theme.types'
-import { filterEnabled, mergeThemes, toDisplayName } from './utils'
+import {
+  filterEnabled,
+  mergeThemes,
+  toDisplayName,
+  toggleSnippetId,
+} from './utils'
 
 describe('toDisplayName', () => {
   it('replaces hyphens with spaces and title-cases each word', () => {
@@ -128,6 +133,26 @@ describe('AppearanceSettings schema — disabled snippets', () => {
     expect(result.success).toBe(true)
     if (result.success)
       expect(result.data.disabledGlobalSnippets).toEqual(['nord', 'dracula'])
+  })
+})
+
+describe('toggleSnippetId', () => {
+  it('adds id to disabled list when snippet is currently enabled', () => {
+    expect(toggleSnippetId([], 'nord')).toEqual(['nord'])
+  })
+
+  it('removes id from disabled list when snippet is currently disabled', () => {
+    expect(toggleSnippetId(['nord', 'dracula'], 'nord')).toEqual(['dracula'])
+  })
+
+  it('does not mutate the original array', () => {
+    const disabled = ['nord']
+    toggleSnippetId(disabled, 'dracula')
+    expect(disabled).toEqual(['nord'])
+  })
+
+  it('returns empty array when toggling the only disabled snippet on', () => {
+    expect(toggleSnippetId(['nord'], 'nord')).toEqual([])
   })
 })
 

--- a/src/lib/themes/utils.ts
+++ b/src/lib/themes/utils.ts
@@ -3,6 +3,9 @@ import type { SnippetDescriptor, ThemeDescriptor } from './theme.types'
 export const toDisplayName = (folderName: string): string =>
   folderName.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 
+export const toggleSnippetId = (disabled: string[], id: string): string[] =>
+  disabled.includes(id) ? disabled.filter((d) => d !== id) : [...disabled, id]
+
 export const filterEnabled = (
   descriptors: SnippetDescriptor[],
   disabled: string[],

--- a/src/routes/workspace/$workspaceId/notes/$noteId.tsx
+++ b/src/routes/workspace/$workspaceId/notes/$noteId.tsx
@@ -32,7 +32,12 @@ function NoteIdComponent() {
   }, [workspaceId, noteId, openTab])
 
   return (
-    <NoteView key={noteId} workspaceId={workspaceId} noteId={noteId} note={note} />
+    <NoteView
+      key={noteId}
+      workspaceId={workspaceId}
+      noteId={noteId}
+      note={note}
+    />
   )
 }
 


### PR DESCRIPTION
Closes #22

## Summary

- Adds **Global Snippets** and **Workspace Snippets** sections to Settings > Appearance, each with a per-snippet toggle list, an "Open folder" button, and an empty state
- Introduces `toggleSnippetId` pure helper (with tests) to add/remove a snippet ID from the disabled list
- Adds `openAppDataPath` utility to open the global snippets folder in the OS file manager, and updates the `opener:allow-open-path` capability to allow `$APPDATA/**`
- Fixes snippet style flash on note navigation: `SnippetsProvider` no longer strips all `<style>` tags synchronously before the async reload — stale styles are removed only after new ones are injected

## Test plan

- [x] Open Settings > Appearance and verify Global Snippets and Workspace Snippets sections appear
- [x] Add a `.css` file to the global snippets folder and confirm it appears in the list with the correct display name (hyphen/underscore → Title Case)
- [x] Toggle a global snippet off and confirm it is disabled immediately (style removed) and the setting persists on reload
- [x] Toggle it back on and confirm it re-enables
- [x] Verify toggling in one workspace does not affect the toggle state in another workspace
- [x] Click "Open global snippets folder" and confirm the correct AppData directory opens
- [x] Click "Open workspace snippets folder" and confirm the correct `.config/snippets/` directory opens
- [x] Open a workspace with no snippets and confirm the empty state message is shown
- [x] Navigate between notes with CSS snippets applied and verify no style flash occurs