### PR TITLE
feat(snippets): add Reload styles button (#23)

### DIFF
--- a/src/components/providers/SnippetsProvider.tsx
+++ b/src/components/providers/SnippetsProvider.tsx
@@ -1,21 +1,12 @@
 import { useEffect } from 'react'
 import { useAppearanceSettings } from '@/lib/settings'
 import { filterEnabled, loadCssSnippets, readSnippetCss } from '@/lib/themes'
-
-const GLOBAL_ATTR = 'data-nemos-snippet-global'
-const WORKSPACE_ATTR = 'data-nemos-snippet-workspace'
-
-function injectSnippetStyle(attr: string, id: string, css: string) {
-  const existing = document.querySelector(`[${attr}="${id}"]`)
-  if (existing) {
-    existing.textContent = css
-    return
-  }
-  const style = document.createElement('style')
-  style.setAttribute(attr, id)
-  style.textContent = css
-  document.head.appendChild(style)
-}
+import {
+  GLOBAL_ATTR,
+  injectSnippetStyle,
+  removeStaleSnippets,
+  WORKSPACE_ATTR,
+} from '@/lib/themes/style-injectors'
 
 export const SnippetsProvider = ({
   children,
@@ -69,13 +60,8 @@ export const SnippetsProvider = ({
 
         if (cancelled) return
 
-        document.querySelectorAll(`[${GLOBAL_ATTR}]`).forEach((el) => {
-          if (!nextGlobalIds.has(el.getAttribute(GLOBAL_ATTR)!)) el.remove()
-        })
-        document.querySelectorAll(`[${WORKSPACE_ATTR}]`).forEach((el) => {
-          if (!nextWorkspaceIds.has(el.getAttribute(WORKSPACE_ATTR)!))
-            el.remove()
-        })
+        removeStaleSnippets(GLOBAL_ATTR, nextGlobalIds)
+        removeStaleSnippets(WORKSPACE_ATTR, nextWorkspaceIds)
       },
     )
 

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react'
 import { useAppearanceSettings } from '@/lib/settings'
 import { readThemeCss } from '@/lib/themes'
-
-const THEME_STYLE_ATTR = 'data-nemos-theme'
+import { applyThemeCSS } from '@/lib/themes/style-injectors'
 
 function getSystemTheme(): 'light' | 'dark' {
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -12,22 +11,6 @@ function getSystemTheme(): 'light' | 'dark' {
 
 function applyTheme(resolved: 'light' | 'dark') {
   document.documentElement.classList.toggle('dark', resolved === 'dark')
-}
-
-function applyThemeCSS(css: string | null) {
-  const existing = document.querySelector(`[${THEME_STYLE_ATTR}]`)
-  if (!css) {
-    existing?.remove()
-    return
-  }
-  if (existing) {
-    existing.textContent = css
-  } else {
-    const style = document.createElement('style')
-    style.setAttribute(THEME_STYLE_ATTR, '')
-    style.textContent = css
-    document.head.appendChild(style)
-  }
 }
 
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog'
+import { ScrollArea } from '../ui/scroll-area'
 import { SidebarProvider } from '../ui/sidebar'
 import { type CategoryId, SettingsSidebar } from './SettingsSidebar'
 
@@ -47,7 +48,7 @@ export const SettingsDialog = () => {
 
   return (
     <Dialog open={isOpen('settings')} onOpenChange={close}>
-      <DialogContent className="h-full overflow-hidden p-0 sm:max-w-3xl md:max-h-[500px]">
+      <DialogContent className="h-full overflow-hidden p-0 sm:max-w-3xl md:max-h-125">
         <DialogHeader className="sr-only">
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription>Application settings</DialogDescription>
@@ -59,19 +60,21 @@ export const SettingsDialog = () => {
               '--sidebar-width-mobile': '10rem',
             } as React.CSSProperties
           }
-          className="min-h-full items-start"
+          className="h-full min-h-0! items-start"
         >
           <SettingsSidebar
             activeCategory={activeCategory}
             onCategoryChange={setActiveCategory}
           />
-          <main className="flex-1 p-5">
-            <Suspense fallback={<Loader2 className="size-4 animate-spin" />}>
-              <div className="fade-in animate-in duration-200">
-                <Section />
-              </div>
-            </Suspense>
-          </main>
+          <ScrollArea className="h-full flex-1">
+            <main className="p-5">
+              <Suspense fallback={<Loader2 className="size-4 animate-spin" />}>
+                <div className="fade-in animate-in duration-200">
+                  <Section />
+                </div>
+              </Suspense>
+            </main>
+          </ScrollArea>
         </SidebarProvider>
       </DialogContent>
     </Dialog>

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, MonitorCog, Moon, Sun } from 'lucide-react'
+import { FolderOpen, MonitorCog, Moon, RefreshCw, Sun } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
@@ -17,6 +17,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { SNIPPETS_DIR, WORKSPACE_SNIPPETS_DIR } from '@/config/constants'
+import { useReloadStyles } from '@/hooks/use-reload-styles'
 import { ensureDir, ensureDirAppData } from '@/lib/fs'
 import { openAppDataPath, openPath } from '@/lib/opener'
 import type { Theme } from '@/lib/settings'
@@ -52,6 +53,8 @@ export const AppearanceSection = () => {
   const update = useAppearanceSettings((s) => s.update)
   const revertKey = useAppearanceSettings((s) => s.revertKey)
   const workspaceDelta = useAppearanceSettings((s) => s.workspaceDelta)
+
+  const reloadStyles = useReloadStyles()
 
   const [availableThemes, setAvailableThemes] = useState<ThemeDescriptor[]>([])
   const [globalSnippets, setGlobalSnippets] = useState<SnippetDescriptor[]>([])
@@ -94,6 +97,13 @@ export const AppearanceSection = () => {
   const handleToggleWorkspaceSnippet = (id: string) => {
     update({
       disabledWorkspaceSnippets: toggleSnippetId(disabledWorkspaceSnippets, id),
+    })
+  }
+
+  const handleReloadStyles = () => {
+    reloadStyles().then(({ globalSnippets, workspaceSnippets }) => {
+      setGlobalSnippets(globalSnippets)
+      setWorkspaceSnippets(workspaceSnippets)
     })
   }
 
@@ -280,6 +290,18 @@ export const AppearanceSection = () => {
           ))}
         </div>
       )}
+
+      <Separator />
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full"
+        onClick={handleReloadStyles}
+      >
+        <RefreshCw className="size-3.5" />
+        Reload styles
+      </Button>
     </div>
   )
 }

--- a/src/hooks/use-reload-styles.ts
+++ b/src/hooks/use-reload-styles.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react'
+import { useAppearanceSettings } from '@/lib/settings'
+import { reloadStyles } from '@/lib/themes/reload-styles'
+import type { SnippetDescriptor } from '@/lib/themes/theme.types'
+
+interface ReloadResult {
+  globalSnippets: SnippetDescriptor[]
+  workspaceSnippets: SnippetDescriptor[]
+}
+
+export function useReloadStyles(): () => Promise<ReloadResult> {
+  const activeTheme = useAppearanceSettings((s) => s.activeTheme)
+  const workspacePath = useAppearanceSettings((s) => s.workspacePath)
+  const disabledGlobalSnippets = useAppearanceSettings(
+    (s) => s.disabledGlobalSnippets,
+  )
+  const disabledWorkspaceSnippets = useAppearanceSettings(
+    (s) => s.disabledWorkspaceSnippets,
+  )
+
+  return useCallback(
+    () =>
+      reloadStyles({
+        activeTheme,
+        workspacePath,
+        disabledGlobalSnippets,
+        disabledWorkspaceSnippets,
+      }),
+    [
+      activeTheme,
+      workspacePath,
+      disabledGlobalSnippets,
+      disabledWorkspaceSnippets,
+    ],
+  )
+}

--- a/src/lib/themes/reload-styles.test.ts
+++ b/src/lib/themes/reload-styles.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { reloadStyles } from './reload-styles'
+
+const {
+  mockReadThemeCss,
+  mockLoadCssSnippets,
+  mockReadSnippetCss,
+  mockApplyThemeCSS,
+  mockInjectSnippetStyle,
+  mockRemoveStaleSnippets,
+} = vi.hoisted(() => ({
+  mockReadThemeCss: vi.fn(),
+  mockLoadCssSnippets: vi.fn(),
+  mockReadSnippetCss: vi.fn(),
+  mockApplyThemeCSS: vi.fn(),
+  mockInjectSnippetStyle: vi.fn(),
+  mockRemoveStaleSnippets: vi.fn(),
+}))
+
+vi.mock('@/lib/themes/service/read-theme-css', () => ({
+  readThemeCss: mockReadThemeCss,
+}))
+vi.mock('@/lib/themes/service/load-css-snippets', () => ({
+  loadCssSnippets: mockLoadCssSnippets,
+}))
+vi.mock('@/lib/themes/service/read-snippet-css', () => ({
+  readSnippetCss: mockReadSnippetCss,
+}))
+vi.mock('@/lib/themes/style-injectors', () => ({
+  applyThemeCSS: mockApplyThemeCSS,
+  injectSnippetStyle: mockInjectSnippetStyle,
+  removeStaleSnippets: mockRemoveStaleSnippets,
+  GLOBAL_ATTR: 'data-nemos-snippet-global',
+  WORKSPACE_ATTR: 'data-nemos-snippet-workspace',
+}))
+
+const WORKSPACE = 'nemos-app/my-workspace'
+const snippet = (id: string) => ({ id, displayName: id })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockLoadCssSnippets.mockResolvedValue({
+    globalSnippets: [],
+    workspaceSnippets: [],
+  })
+  mockReadSnippetCss.mockResolvedValue(null)
+})
+
+describe('reloadStyles — theme', () => {
+  it('reads and applies active theme CSS', async () => {
+    mockReadThemeCss.mockResolvedValue('body { color: red }')
+
+    await reloadStyles({
+      activeTheme: 'nord',
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(mockReadThemeCss).toHaveBeenCalledWith('nord', WORKSPACE)
+    expect(mockApplyThemeCSS).toHaveBeenCalledWith('body { color: red }')
+  })
+
+  it('applies null CSS to remove theme style tag when activeTheme is null', async () => {
+    await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(mockReadThemeCss).not.toHaveBeenCalled()
+    expect(mockApplyThemeCSS).toHaveBeenCalledWith(null)
+  })
+})
+
+describe('reloadStyles — snippets', () => {
+  it('injects CSS for each enabled snippet', async () => {
+    mockReadThemeCss.mockResolvedValue(null)
+    mockLoadCssSnippets.mockResolvedValue({
+      globalSnippets: [snippet('nord'), snippet('dracula')],
+      workspaceSnippets: [snippet('custom')],
+    })
+    mockReadSnippetCss.mockImplementation(
+      (_scope: string, filename: string) => `/* ${filename} */`,
+    )
+
+    await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(mockInjectSnippetStyle).toHaveBeenCalledWith(
+      'data-nemos-snippet-global',
+      'nord',
+      '/* nord.css */',
+    )
+    expect(mockInjectSnippetStyle).toHaveBeenCalledWith(
+      'data-nemos-snippet-global',
+      'dracula',
+      '/* dracula.css */',
+    )
+    expect(mockInjectSnippetStyle).toHaveBeenCalledWith(
+      'data-nemos-snippet-workspace',
+      'custom',
+      '/* custom.css */',
+    )
+  })
+
+  it('does not inject disabled snippets', async () => {
+    mockReadThemeCss.mockResolvedValue(null)
+    mockLoadCssSnippets.mockResolvedValue({
+      globalSnippets: [snippet('nord'), snippet('dracula')],
+      workspaceSnippets: [],
+    })
+    mockReadSnippetCss.mockResolvedValue('/* css */')
+
+    await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: ['nord'],
+      disabledWorkspaceSnippets: [],
+    })
+
+    const calls = mockInjectSnippetStyle.mock.calls
+    expect(calls.every(([, id]) => id !== 'nord')).toBe(true)
+  })
+
+  it('removes stale snippet style tags', async () => {
+    mockReadThemeCss.mockResolvedValue(null)
+    mockLoadCssSnippets.mockResolvedValue({
+      globalSnippets: [snippet('nord')],
+      workspaceSnippets: [],
+    })
+    mockReadSnippetCss.mockResolvedValue('/* css */')
+
+    await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(mockRemoveStaleSnippets).toHaveBeenCalledWith(
+      'data-nemos-snippet-global',
+      new Set(['nord']),
+    )
+    expect(mockRemoveStaleSnippets).toHaveBeenCalledWith(
+      'data-nemos-snippet-workspace',
+      new Set(),
+    )
+  })
+
+  it('returns updated globalSnippets and workspaceSnippets', async () => {
+    mockReadThemeCss.mockResolvedValue(null)
+    mockLoadCssSnippets.mockResolvedValue({
+      globalSnippets: [snippet('nord')],
+      workspaceSnippets: [snippet('custom')],
+    })
+    mockReadSnippetCss.mockResolvedValue('/* css */')
+
+    const result = await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(result.globalSnippets).toEqual([snippet('nord')])
+    expect(result.workspaceSnippets).toEqual([snippet('custom')])
+  })
+})
+
+describe('reloadStyles — edge cases', () => {
+  it('returns empty lists and skips snippet loading when workspacePath is null', async () => {
+    const result = await reloadStyles({
+      activeTheme: null,
+      workspacePath: null,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(result).toEqual({ globalSnippets: [], workspaceSnippets: [] })
+    expect(mockLoadCssSnippets).not.toHaveBeenCalled()
+  })
+
+  it('returns empty lists when snippet folder is missing', async () => {
+    mockReadThemeCss.mockResolvedValue(null)
+    mockLoadCssSnippets.mockRejectedValue(new Error('not found'))
+
+    const result = await reloadStyles({
+      activeTheme: null,
+      workspacePath: WORKSPACE,
+      disabledGlobalSnippets: [],
+      disabledWorkspaceSnippets: [],
+    })
+
+    expect(result).toEqual({ globalSnippets: [], workspaceSnippets: [] })
+  })
+})

--- a/src/lib/themes/reload-styles.ts
+++ b/src/lib/themes/reload-styles.ts
@@ -1,0 +1,84 @@
+import { loadCssSnippets } from './service/load-css-snippets'
+import { readSnippetCss } from './service/read-snippet-css'
+import { readThemeCss } from './service/read-theme-css'
+import {
+  applyThemeCSS,
+  GLOBAL_ATTR,
+  injectSnippetStyle,
+  removeStaleSnippets,
+  WORKSPACE_ATTR,
+} from './style-injectors'
+import type { SnippetDescriptor } from './theme.types'
+import { filterEnabled } from './utils'
+
+interface ReloadStylesParams {
+  activeTheme: string | null
+  workspacePath: string | null
+  disabledGlobalSnippets: string[]
+  disabledWorkspaceSnippets: string[]
+}
+
+interface ReloadStylesResult {
+  globalSnippets: SnippetDescriptor[]
+  workspaceSnippets: SnippetDescriptor[]
+}
+
+export async function reloadStyles({
+  activeTheme,
+  workspacePath,
+  disabledGlobalSnippets,
+  disabledWorkspaceSnippets,
+}: ReloadStylesParams): Promise<ReloadStylesResult> {
+  if (activeTheme) {
+    const css = await readThemeCss(activeTheme, workspacePath)
+    applyThemeCSS(css)
+  } else {
+    applyThemeCSS(null)
+  }
+
+  if (!workspacePath) {
+    return { globalSnippets: [], workspaceSnippets: [] }
+  }
+
+  let globalSnippets: SnippetDescriptor[] = []
+  let workspaceSnippets: SnippetDescriptor[] = []
+
+  try {
+    ;({ globalSnippets, workspaceSnippets } =
+      await loadCssSnippets(workspacePath))
+  } catch {
+    return { globalSnippets: [], workspaceSnippets: [] }
+  }
+
+  const enabledGlobal = filterEnabled(globalSnippets, disabledGlobalSnippets)
+  const enabledWorkspace = filterEnabled(
+    workspaceSnippets,
+    disabledWorkspaceSnippets,
+  )
+
+  for (const snippet of enabledGlobal) {
+    const css = await readSnippetCss(
+      'global',
+      `${snippet.id}.css`,
+      workspacePath,
+    )
+    if (css) injectSnippetStyle(GLOBAL_ATTR, snippet.id, css)
+  }
+
+  for (const snippet of enabledWorkspace) {
+    const css = await readSnippetCss(
+      'workspace',
+      `${snippet.id}.css`,
+      workspacePath,
+    )
+    if (css) injectSnippetStyle(WORKSPACE_ATTR, snippet.id, css)
+  }
+
+  removeStaleSnippets(GLOBAL_ATTR, new Set(enabledGlobal.map((s) => s.id)))
+  removeStaleSnippets(
+    WORKSPACE_ATTR,
+    new Set(enabledWorkspace.map((s) => s.id)),
+  )
+
+  return { globalSnippets, workspaceSnippets }
+}

--- a/src/lib/themes/style-injectors.ts
+++ b/src/lib/themes/style-injectors.ts
@@ -1,0 +1,37 @@
+export const THEME_ATTR = 'data-nemos-theme'
+export const GLOBAL_ATTR = 'data-nemos-snippet-global'
+export const WORKSPACE_ATTR = 'data-nemos-snippet-workspace'
+
+export function applyThemeCSS(css: string | null) {
+  const existing = document.querySelector(`[${THEME_ATTR}]`)
+  if (!css) {
+    existing?.remove()
+    return
+  }
+  if (existing) {
+    existing.textContent = css
+  } else {
+    const style = document.createElement('style')
+    style.setAttribute(THEME_ATTR, '')
+    style.textContent = css
+    document.head.appendChild(style)
+  }
+}
+
+export function injectSnippetStyle(attr: string, id: string, css: string) {
+  const existing = document.querySelector(`[${attr}="${id}"]`)
+  if (existing) {
+    existing.textContent = css
+    return
+  }
+  const style = document.createElement('style')
+  style.setAttribute(attr, id)
+  style.textContent = css
+  document.head.appendChild(style)
+}
+
+export function removeStaleSnippets(attr: string, activeIds: Set<string>) {
+  document.querySelectorAll(`[${attr}]`).forEach((el) => {
+    if (!activeIds.has(el.getAttribute(attr)!)) el.remove()
+  })
+}


### PR DESCRIPTION
## Summary

- Adds a **Reload styles** button to Settings > Appearance that re-reads the active theme and all enabled CSS snippets from disk and re-injects them without restarting the app
- Extracts shared DOM injection helpers (`applyThemeCSS`, `injectSnippetStyle`, `removeStaleSnippets`) into `src/lib/themes/style-injectors.ts`, used by both the existing providers and the new reload logic
- Implements `reloadStyles()` pure async function with 8 unit tests covering all acceptance criteria
- Adds `useReloadStyles` hook wiring the function to the settings store
- Fixes settings dialog scroll via `ScrollArea` + `min-h-0!` override on `SidebarProvider`

## Test plan

- [x] "Reload styles" button is visible in Settings > Appearance
- [x] Clicking it re-injects the active theme CSS (edit theme file on disk, click, see change)
- [x] Clicking it re-injects enabled snippet CSS (edit snippet file on disk, click, see change)
- [x] Snippet list refreshes after click (add/remove a `.css` file, click, list updates)
- [x] Works with no active theme selected
- [x] Works when snippets folder is empty or missing
- [x] Settings dialog scrolls correctly on the Appearance tab

Closes #23