### PR TITLE
feat: stable semantic CSS class layer as theming API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- **Stable semantic theming API**: A stable layer of semantic CSS classes is now applied to key DOM regions.
 - **CSS Snippets**: Drop individual `.css` files into the global snippets folder (`<AppData>/snippets/`) or into a workspace's `.config/snippets/` folder to apply additive styles on top of the active theme. All snippets are enabled by default; each can independently be toggled on or off per workspace from Settings > Appearance. Global snippets are injected first; workspace snippets follow, so workspace rules win on any property conflict via the CSS cascade.
 - **Custom theme system**: Drop a folder containing a `theme.css` file into the global themes directory or the workspace themes directory (`.config/themes/<ThemeID>/`). Theme CSS is injected after the app's base styles so the app never breaks regardless of what the file contains. The light/dark/system toggle continues to work independently. Themes are discovered from both scopes each time Appearance settings opens, workspace themes override global themes with the same ID.
 - **Two-layer settings (Global + Workspace)**: Settings now operate on two layers — a Global Settings file in the OS app data directory and a per-workspace `.config/settings.json`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ A Theme installed in the OS app data directory, available across all Workspaces.
 #### Workspace Theme
 A Theme installed inside a Workspace's `.config/themes/[ThemeID]/` directory, scoped to that Workspace. Overrides a Global Theme with the same ID.
 
-> **CSS variable contract:** Theme authors can override any CSS variable or class the app currently exposes. No stability guarantee is made yet — the authoritative list and any public API contract will be defined as part of the planned CSS classes rethink.
+> **Theming API:** Theme authors can override any CSS variable, target any structural selector, or inject arbitrary CSS. The stable selectors and variables that form the public contract are documented in `docs/theming.md`.
 
 ### CSS Snippet
 A flat `.css` file placed in a snippets folder that is injected into the app after the base styles and any active Theme. CSS Snippets augment rather than replace existing styles. Unlike Themes, a CSS Snippet is a single file — there is no enclosing folder.

--- a/docs/adr/0006-stable-semantic-css-class-layer-as-theming-api.md
+++ b/docs/adr/0006-stable-semantic-css-class-layer-as-theming-api.md
@@ -1,0 +1,15 @@
+# Stable semantic CSS class layer as the public theming API
+
+Nemos exposes a stable set of CSS class names on structural DOM regions and custom block elements. These classes form the public theming API alongside the CSS custom properties in `src/index.css`. The full contract is documented in `docs/theming.md`.
+
+**Structural classes:** `.sidebar`, `.topbar`, `.content`, `.note`, `.editor`
+
+**Block-level classes:** `.codeblock`, `.mermaid`, `.math-display`, `.math-inline`, `.smiles`, `.table-wrapper`
+
+These names are owned by Nemos and will not change when internal dependencies (Tailwind, shadcn/ui, TipTap, or DOM structure) are refactored. No `nemos-` namespace prefix is used.
+
+The alternative was to expose only CSS custom properties and let theme authors rely on Tailwind utility classes or shadcn `data-*` attributes for structural targeting. We rejected it because theme authors who want to recreate a full visual experience (typography, layout, spacing, custom block appearance) cannot do so through variable overrides alone — they need stable selectors to target specific regions of the UI independently. Without an owned semantic layer, any internal refactor could silently break user-authored themes.
+
+No `nemos-` prefix was applied to the class names. The app runs in a sandboxed Tauri webview where external CSS collision is not a risk, and documentation — not naming convention — is what makes a contract stable. Shorter names are more ergonomic for theme authors.
+
+`data-*` attributes from shadcn/ui and DOM hierarchy are acceptable for advanced state-based targeting by theme authors, but are explicitly documented as non-stable hooks subject to change with component library updates.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,151 @@
+# Nemos Theming API
+
+This document defines the public CSS contract for Nemos Themes and CSS Snippets. Selectors and variables listed here are stable — they will not be renamed or removed without a major version bump.
+
+Theme authors can override any CSS variable, target any structural selector, or inject arbitrary CSS. There is no restriction to variable-only overrides.
+
+---
+
+## Injection order
+
+Styles are applied in this order:
+
+1. Nemos base styles
+2. Active Theme (`theme.css`)
+3. CSS Snippets — Global first, then Workspace
+
+Later layers win on any property conflict via CSS cascade. A Theme that only overrides one variable leaves everything else untouched.
+
+---
+
+## Light and dark mode
+
+The `.dark` class is toggled on `<html>` by the app. Theme authors can target either mode:
+
+```css
+/* light mode */
+.note { background: white; }
+
+/* dark mode */
+.dark .note { background: #111; }
+```
+
+The light/dark/system toggle works independently of the active Theme.
+
+---
+
+## Structural selectors
+
+These classes are owned by Nemos and stable across internal refactors. They will not change when Tailwind, shadcn/ui, or other internal dependencies are updated.
+
+| Selector | Region |
+|----------|--------|
+| `.sidebar` | Sidebar panel |
+| `.topbar` | Tab bar and top header area |
+| `.content` | Main content area (everything to the right of the sidebar) |
+| `.note` | Note container. Also receives the value of the `cssClass` frontmatter field as an additional class. |
+| `.editor` | Editable/rendered content body inside a note |
+
+---
+
+## Block-level selectors
+
+These classes are on custom block wrappers rendered inside `.editor`.
+
+| Selector | Block |
+|----------|-------|
+| `.codeblock` | Code block |
+| `.mermaid` | Mermaid diagram |
+| `.math-display` | Display math (block) |
+| `.math-inline` | Inline math |
+| `.smiles` | SMILES molecule diagram |
+| `.table-wrapper` | Table |
+
+Standard HTML elements inside `.editor` are also reliable targets: `h1`–`h6`, `p`, `blockquote`, `code`, `pre`, `ul`, `ol`, `li`, `a`, `img`, `hr`.
+
+---
+
+## CSS custom properties
+
+All CSS custom properties defined in `src/index.css` are part of the public contract. Theme authors may override any of them. Dark mode overrides are defined on `.dark` — override the same variables there to change dark mode appearance.
+
+### Color and surface tokens
+
+| Variable | Purpose |
+|----------|---------|
+| `--background` | App background |
+| `--foreground` | Default text color |
+| `--card` | Card/panel background |
+| `--card-foreground` | Card text |
+| `--popover` | Popover background |
+| `--popover-foreground` | Popover text |
+| `--primary` | Primary accent color |
+| `--primary-foreground` | Text on primary |
+| `--secondary` | Secondary surface |
+| `--secondary-foreground` | Text on secondary |
+| `--muted` | Muted surface (subdued backgrounds) |
+| `--muted-foreground` | Muted text |
+| `--accent` | Accent surface (hover states, highlights) |
+| `--accent-foreground` | Text on accent |
+| `--destructive` | Destructive action color |
+| `--border` | Default border color |
+| `--input` | Input field border |
+| `--ring` | Focus ring |
+| `--selection` | Text selection background |
+| `--selection-foreground` | Text selection foreground |
+| `--radius` | Base border radius |
+
+### Sidebar tokens
+
+| Variable | Purpose |
+|----------|---------|
+| `--sidebar` | Sidebar background |
+| `--sidebar-foreground` | Sidebar text |
+| `--sidebar-primary` | Sidebar primary accent |
+| `--sidebar-primary-foreground` | Text on sidebar primary |
+| `--sidebar-accent` | Sidebar hover/accent surface |
+| `--sidebar-accent-foreground` | Text on sidebar accent |
+| `--sidebar-border` | Sidebar border |
+| `--sidebar-ring` | Sidebar focus ring |
+
+### Code block syntax colors
+
+Eleven slots for syntax highlighting, mapped to token categories by the built-in highlight theme. Override any slot to adjust the color for all tokens assigned to it.
+
+`--codeblock-highlight-1` through `--codeblock-highlight-11`
+
+### Mermaid diagram colors
+
+| Variable | Purpose |
+|----------|---------|
+| `--mermaid-primary-color` | Node fill |
+| `--mermaid-primary-text-color` | Node text |
+| `--mermaid-primary-border-color` | Node border |
+| `--mermaid-line-color` | Connector lines |
+| `--mermaid-secondary-color` | Secondary node fill |
+| `--mermaid-tertiary-color` | Tertiary node fill |
+| `--mermaid-edge-label-background` | Edge label background |
+| `--mermaid-edge-label-color` | Edge label text |
+
+### SMILES molecule colors
+
+One variable per element symbol, used by the SMILES chemistry renderer:
+
+`--smiles-color-c`, `--smiles-color-o`, `--smiles-color-n`, `--smiles-color-f`, `--smiles-color-cl`, `--smiles-color-br`, `--smiles-color-i`, `--smiles-color-p`, `--smiles-color-s`, `--smiles-color-b`, `--smiles-color-si`, `--smiles-color-h`, `--smiles-color-background`
+
+### Chart colors
+
+`--chart-1` through `--chart-5`
+
+---
+
+## Implementation-specific hooks
+
+The following attributes exist on DOM elements and can be used for state-based targeting. They are **not part of the stable contract** — they may change when underlying component libraries are updated. Themes relying on them may need adjustments across major versions.
+
+- `data-sidebar` — attributes on shadcn/ui sidebar elements (`data-sidebar="sidebar"`, `data-sidebar="content"`, etc.)
+- `data-slot` — shadcn/ui component region markers
+- `data-state` — open/closed/active states (e.g., `data-state="open"`)
+- `data-collapsible`, `data-variant`, `data-side` — sidebar configuration attributes
+
+DOM hierarchy (parent/child/sibling relationships) is similarly not guaranteed stable, but is a normal part of CSS authoring and can be used for advanced targeting.

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -35,7 +35,7 @@ export const Editor = ({
       editorProps: {
         attributes: {
           class: cn(
-            'typography focus:outline-none relative',
+            'typography editor focus:outline-none relative',
             className,
             cssClass,
           ),

--- a/src/components/editor/editor.css
+++ b/src/components/editor/editor.css
@@ -164,7 +164,7 @@
 
     /* ── Tables ─────────────────────────────────────── */
 
-    .tableWrapper {
+    .table-wrapper {
       position: relative;
       margin-top: calc(var(--spacing) * 7);
       margin-bottom: calc(var(--spacing) * 7);

--- a/src/components/editor/extensions/higlights.css
+++ b/src/components/editor/extensions/higlights.css
@@ -3,7 +3,7 @@ code .hljs-variable,
 code .hljs-variable.language_,
 code .hljs-name,
 code .hljs-selector-attr {
-  color: var(--codeblock-higlight-1);
+  color: var(--codeblock-highlight-1);
 }
 
 code .hljs-built_in,
@@ -12,20 +12,20 @@ code .hljs-deletion,
 code .hljs-strong,
 code .hljs-emphasis,
 code .hljs-tag {
-  color: var(--codeblock-higlight-2);
+  color: var(--codeblock-highlight-2);
 }
 
 code .hljs-type,
 code .hljs-title.class_,
 code .hljs-selector-tag {
-  color: var(--codeblock-higlight-3);
+  color: var(--codeblock-highlight-3);
 }
 code .hljs-title,
 code .hljs-title.function_,
 code .hljs-section,
 code .hljs-attr,
 code .hljs-selector-id {
-  color: var(--codeblock-higlight-4);
+  color: var(--codeblock-highlight-4);
 }
 
 code .hljs-selector-class,
@@ -33,13 +33,13 @@ code .hljs-selector-pseudo,
 code .hljs-property,
 code .hljs-bullet,
 code .hljs-formula {
-  color: var(--codeblock-higlight-5);
+  color: var(--codeblock-highlight-5);
 }
 
 code .hljs-template-tag,
 code .hljs-template-variable,
 code .hljs-symbol {
-  color: var(--codeblock-higlight-6);
+  color: var(--codeblock-highlight-6);
 }
 
 code .hljs-literal,
@@ -47,13 +47,13 @@ code .hljs-number,
 code .hljs-variable.constant_,
 code .hljs-regexp,
 code .hljs-meta {
-  color: var(--codeblock-higlight-7);
+  color: var(--codeblock-highlight-7);
 }
 
 code .hljs-operator,
 code .hljs-tag.hljs-string,
 code .hljs-link {
-  color: var(--codeblock-higlight-8);
+  color: var(--codeblock-highlight-8);
 }
 
 code .hljs-string,
@@ -62,17 +62,17 @@ code .hljs-code,
 code .hljs-quote,
 code .hljs-addition,
 code .hljs-attribute {
-  color: var(--codeblock-higlight-9);
+  color: var(--codeblock-highlight-9);
 }
 
 code .hljs-subst,
 code .hljs-params,
 code .hljs-punctuation {
-  color: var(--codeblock-higlight-10);
+  color: var(--codeblock-highlight-10);
 }
 
 code .hljs-comment {
-  color: var(--codeblock-higlight-11);
+  color: var(--codeblock-highlight-11);
 }
 
 code .hljs-strong {

--- a/src/components/editor/extensions/table/Table.tsx
+++ b/src/components/editor/extensions/table/Table.tsx
@@ -15,7 +15,7 @@ export default function TableNodeView({ node, editor, getPos }: NodeViewProps) {
   )
 
   return (
-    <NodeViewWrapper className="tableWrapper">
+    <NodeViewWrapper className="table-wrapper">
       <NodeViewContent />
       {isInsideNode(
         editor.state.selection.from,

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -3,7 +3,7 @@ import { SidebarTrigger } from '../ui/sidebar'
 
 export const Topbar = () => {
   return (
-    <div className="flex items-center justify-between gap-2 overflow-hidden border-border border-b px-2.5">
+    <div className="topbar flex items-center justify-between gap-2 overflow-hidden border-border border-b px-2.5">
       <SidebarTrigger className="mx-1 my-2 size-8" />
       <Tabs />
     </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -278,7 +278,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+          className="sidebar flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
         >
           {children}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -80,17 +80,17 @@ body {
   --sidebar-ring: oklch(0.708 0 0);
 
   /* Code Block colors  */
-  --codeblock-higlight-1: #8839ef;
-  --codeblock-higlight-2: #d20f39;
-  --codeblock-higlight-3: #df8e1d;
-  --codeblock-higlight-4: #7287fd;
-  --codeblock-higlight-5: #179299;
-  --codeblock-higlight-6: #dd7878;
-  --codeblock-higlight-7: #fe640b;
-  --codeblock-higlight-8: #209fb5;
-  --codeblock-higlight-9: #40a02b;
-  --codeblock-higlight-10: #5c5f77;
-  --codeblock-higlight-11: #a3a3a3;
+  --codeblock-highlight-1: #8839ef;
+  --codeblock-highlight-2: #d20f39;
+  --codeblock-highlight-3: #df8e1d;
+  --codeblock-highlight-4: #7287fd;
+  --codeblock-highlight-5: #179299;
+  --codeblock-highlight-6: #dd7878;
+  --codeblock-highlight-7: #fe640b;
+  --codeblock-highlight-8: #209fb5;
+  --codeblock-highlight-9: #40a02b;
+  --codeblock-highlight-10: #5c5f77;
+  --codeblock-highlight-11: #a3a3a3;
 }
 
 .dark {
@@ -157,17 +157,17 @@ body {
   --sidebar-ring: oklch(0.556 0 0);
 
   /* Code Block colors  */
-  --codeblock-higlight-1: #ca9ee6;
-  --codeblock-higlight-2: #e78284;
-  --codeblock-higlight-3: #e5c890;
-  --codeblock-higlight-4: #8caaee;
-  --codeblock-higlight-5: #81c8be;
-  --codeblock-higlight-6: #eebebe;
-  --codeblock-higlight-7: #ef9f76;
-  --codeblock-higlight-8: #85c1dc;
-  --codeblock-higlight-9: #a6d189;
-  --codeblock-higlight-10: #b5bfe2;
-  --codeblock-higlight-11: #808080;
+  --codeblock-highlight-1: #ca9ee6;
+  --codeblock-highlight-2: #e78284;
+  --codeblock-highlight-3: #e5c890;
+  --codeblock-highlight-4: #8caaee;
+  --codeblock-highlight-5: #81c8be;
+  --codeblock-highlight-6: #eebebe;
+  --codeblock-highlight-7: #ef9f76;
+  --codeblock-highlight-8: #85c1dc;
+  --codeblock-highlight-9: #a6d189;
+  --codeblock-highlight-10: #b5bfe2;
+  --codeblock-highlight-11: #808080;
 }
 
 @theme inline {

--- a/src/routes/workspace/$workspaceId/notes/$noteId.tsx
+++ b/src/routes/workspace/$workspaceId/notes/$noteId.tsx
@@ -68,7 +68,7 @@ function NoteView({
   )
 
   return (
-    <main className={cn('h-full', frontmatter.cssClass)}>
+    <main className={cn('note h-full', frontmatter.cssClass)}>
       <Suspense fallback={<NotePending />}>
         <NoteProperties
           className="mx-auto w-full max-w-3xl px-10 pt-20"

--- a/src/routes/workspace/$workspaceId/route.tsx
+++ b/src/routes/workspace/$workspaceId/route.tsx
@@ -38,7 +38,7 @@ function RouteComponent() {
     <SidebarProvider>
       <MigrationOverlay workspaceId={workspaceId} legacyCount={legacyCount} />
       <Sidebar />
-      <div className="grid h-screen w-full grid-rows-[auto_1fr] overflow-hidden">
+      <div className="content grid h-screen w-full grid-rows-[auto_1fr] overflow-hidden">
         <Topbar />
         <ScrollArea className="h-full overflow-hidden">
           <Outlet />


### PR DESCRIPTION
Closes #31, closes #32, closes #33, closes #34

## Summary

- Adds stable semantic CSS classes to key DOM regions so theme and CSS Snippet authors have a reliable, documented targeting surface that survives internal Tailwind/shadcn/ui changes
- Renames `.tableWrapper` → `.table-wrapper` to match the published contract in `docs/theming.md`

### Classes added

| Class | Element |
|---|---|
| `.sidebar` | Sidebar panel inner container (`sidebar.tsx`) |
| `.topbar` | Tab bar / header (`Topbar.tsx`) |
| `.content` | Main content area right of sidebar (`route.tsx`) |
| `.note` | Note container — `cssClass` frontmatter value applied as additional class on the same element (`$noteId.tsx`) |
| `.editor` | TipTap `EditorContent` root — `.typography` retained alongside it (`Editor.tsx`) |

### Rename

- `.tableWrapper` → `.table-wrapper` in `Table.tsx` and `editor.css`

## Test plan

- [x] `.sidebar { background: red; }` in a CSS Snippet changes the sidebar background
- [x] `.topbar { background: blue; }` changes the topbar background
- [x] `.content { background: green; }` changes the main content area background
- [x] `.note { max-width: 400px; }` narrows the note container
- [x] A note with `cssClass: my-note` in frontmatter has both `note` and `my-note` on the same element
- [x] `.editor h1 { color: red; }` changes heading color inside a note
- [x] `.typography` is still present on the same element as `.editor`
- [x] `.table-wrapper { border: 2px solid red; }` shows a border around tables; `.tableWrapper` does nothing